### PR TITLE
Add tag support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,9 @@ gem 'paper_trail'
 # Authentication
 gem 'devise'
 
+# Tagging
+gem 'acts-as-taggable-on', '~> 4.0'
+
 # Use CoffeeScript for .coffee assets and views
 # gem 'coffee-rails', '~> 4.2'
 # See https://github.com/rails/execjs#readme for more supported runtimes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,8 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    acts-as-taggable-on (4.0.0)
+      activerecord (>= 4.0)
     arel (7.1.2)
     bcrypt (3.1.11)
     builder (3.2.2)
@@ -196,6 +198,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  acts-as-taggable-on (~> 4.0)
   bundler-audit
   byebug
   devise

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,7 @@
 class Group < ApplicationRecord
   has_paper_trail
+  acts_as_taggable
+
   has_and_belongs_to_many :users
   has_many :lists, as: :owner
 

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,5 +1,7 @@
 class List < ApplicationRecord
   has_paper_trail
+  acts_as_taggable
+
   belongs_to :owner, polymorphic: true
   has_and_belongs_to_many :resources
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,5 +1,7 @@
 class Resource < ApplicationRecord
   has_paper_trail
+  acts_as_taggable
+
   # Warning: since this is an enum (stored as an integer), we need to preserve the original integers
   # each value is associated with. Otherwise the types stored in the database will switch around.
   # See: http://www.justinweiss.com/articles/creating-easy-readable-attributes-with-activerecord-enums/

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   has_paper_trail
+  acts_as_taggable
+
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,0 +1,2 @@
+ActsAsTaggableOn.remove_unused_tags = true
+ActsAsTaggableOn.force_lowercase = true

--- a/db/migrate/20161022021345_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161022021345_acts_as_taggable_on_migration.acts_as_taggable_on_engine.rb
@@ -1,0 +1,31 @@
+# This migration comes from acts_as_taggable_on_engine (originally 1)
+class ActsAsTaggableOnMigration < ActiveRecord::Migration
+  def self.up
+    create_table :tags do |t|
+      t.string :name
+    end
+
+    create_table :taggings do |t|
+      t.references :tag
+
+      # You should make sure that the column created is
+      # long enough to store the required class names.
+      t.references :taggable, polymorphic: true
+      t.references :tagger, polymorphic: true
+
+      # Limit is created to prevent MySQL error on index
+      # length for MyISAM table type: http://bit.ly/vgW2Ql
+      t.string :context, limit: 128
+
+      t.datetime :created_at
+    end
+
+    add_index :taggings, :tag_id
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    drop_table :taggings
+    drop_table :tags
+  end
+end

--- a/db/migrate/20161022021346_add_missing_unique_indices.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161022021346_add_missing_unique_indices.acts_as_taggable_on_engine.rb
@@ -1,0 +1,21 @@
+# This migration comes from acts_as_taggable_on_engine (originally 2)
+class AddMissingUniqueIndices < ActiveRecord::Migration
+  def self.up
+    add_index :tags, :name, unique: true
+
+    remove_index :taggings, :tag_id if index_exists?(:taggings, :tag_id)
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+    add_index :taggings,
+              [:tag_id, :taggable_id, :taggable_type, :context, :tagger_id, :tagger_type],
+              unique: true, name: 'taggings_idx'
+  end
+
+  def self.down
+    remove_index :tags, :name
+
+    remove_index :taggings, name: 'taggings_idx'
+
+    add_index :taggings, :tag_id unless index_exists?(:taggings, :tag_id)
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20161022021347_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161022021347_add_taggings_counter_cache_to_tags.acts_as_taggable_on_engine.rb
@@ -1,0 +1,15 @@
+# This migration comes from acts_as_taggable_on_engine (originally 3)
+class AddTaggingsCounterCacheToTags < ActiveRecord::Migration
+  def self.up
+    add_column :tags, :taggings_count, :integer, default: 0
+
+    ActsAsTaggableOn::Tag.reset_column_information
+    ActsAsTaggableOn::Tag.find_each do |tag|
+      ActsAsTaggableOn::Tag.reset_counters(tag.id, :taggings)
+    end
+  end
+
+  def self.down
+    remove_column :tags, :taggings_count
+  end
+end

--- a/db/migrate/20161022021348_add_missing_taggable_index.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161022021348_add_missing_taggable_index.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 4)
+class AddMissingTaggableIndex < ActiveRecord::Migration
+  def self.up
+    add_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+
+  def self.down
+    remove_index :taggings, [:taggable_id, :taggable_type, :context]
+  end
+end

--- a/db/migrate/20161022021349_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161022021349_change_collation_for_tag_names.acts_as_taggable_on_engine.rb
@@ -1,0 +1,10 @@
+# This migration comes from acts_as_taggable_on_engine (originally 5)
+# This migration is added to circumvent issue #623 and have special characters
+# work properly
+class ChangeCollationForTagNames < ActiveRecord::Migration
+  def up
+    if ActsAsTaggableOn::Utils.using_mysql?
+      execute("ALTER TABLE tags MODIFY name varchar(255) CHARACTER SET utf8 COLLATE utf8_bin;")
+    end
+  end
+end

--- a/db/migrate/20161022021350_add_missing_indexes.acts_as_taggable_on_engine.rb
+++ b/db/migrate/20161022021350_add_missing_indexes.acts_as_taggable_on_engine.rb
@@ -1,0 +1,13 @@
+# This migration comes from acts_as_taggable_on_engine (originally 6)
+class AddMissingIndexes < ActiveRecord::Migration
+  def change
+    add_index :taggings, :tag_id
+    add_index :taggings, :taggable_id
+    add_index :taggings, :taggable_type
+    add_index :taggings, :tagger_id
+    add_index :taggings, :context
+
+    add_index :taggings, [:tagger_id, :tagger_type]
+    add_index :taggings, [:taggable_id, :taggable_type, :tagger_id, :context], name: 'taggings_idy'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161022002433) do
+ActiveRecord::Schema.define(version: 20161022021350) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -58,6 +58,31 @@ ActiveRecord::Schema.define(version: 20161022002433) do
     t.datetime "created_at",                null: false
     t.datetime "updated_at",                null: false
     t.index ["user_id"], name: "index_resources_on_user_id", using: :btree
+  end
+
+  create_table "taggings", force: :cascade do |t|
+    t.integer  "tag_id"
+    t.string   "taggable_type"
+    t.integer  "taggable_id"
+    t.string   "tagger_type"
+    t.integer  "tagger_id"
+    t.string   "context",       limit: 128
+    t.datetime "created_at"
+    t.index ["context"], name: "index_taggings_on_context", using: :btree
+    t.index ["tag_id", "taggable_id", "taggable_type", "context", "tagger_id", "tagger_type"], name: "taggings_idx", unique: true, using: :btree
+    t.index ["tag_id"], name: "index_taggings_on_tag_id", using: :btree
+    t.index ["taggable_id", "taggable_type", "context"], name: "index_taggings_on_taggable_id_and_taggable_type_and_context", using: :btree
+    t.index ["taggable_id", "taggable_type", "tagger_id", "context"], name: "taggings_idy", using: :btree
+    t.index ["taggable_id"], name: "index_taggings_on_taggable_id", using: :btree
+    t.index ["taggable_type"], name: "index_taggings_on_taggable_type", using: :btree
+    t.index ["tagger_id", "tagger_type"], name: "index_taggings_on_tagger_id_and_tagger_type", using: :btree
+    t.index ["tagger_id"], name: "index_taggings_on_tagger_id", using: :btree
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string  "name"
+    t.integer "taggings_count", default: 0
+    t.index ["name"], name: "index_tags_on_name", unique: true, using: :btree
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,16 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
+# Cases we should cover with seeds
+# - User with no resources, no lists, no groups
+# - User with no resources, one list, no groups
+# - User with resource, list, group
+# - User with one group, no list
+# - Group with all users, one list
+# - Group with 2 users, no list
+# - Resource belongs to a user, and two lists
+# - Resource belongs to no user, and two lists
+# - Resource belongs to one list
+# - User's list
+# - User's list
+# - Group's list
 
 # Create users
 (1..5).each do |n|
@@ -15,10 +20,19 @@
   )
 end
 
-# Create 100 fake resources
-(0..100).each do |n|
+# Create 50 fake unowned resources
+(0..50).each do |n|
   Resource.create(
     title: Faker::Book.title,
+    resource_type: Resource.resource_types.keys.sample
+  )
+end
+
+# Create 50 fake owned resources
+(0..50).each do |n|
+  Resource.create(
+    title: Faker::Book.title,
+    user: User.all.sample,
     resource_type: Resource.resource_types.keys.sample
   )
 end
@@ -47,6 +61,8 @@ g2 = Group.create(
 # Assign 2 users to group
 g2.users << User.all
 
+
+# Make lists for everyone
 User.all.each do |user|
   user.lists.create(
     name: Faker::Book.title,
@@ -61,20 +77,3 @@ end
     resources: Resource.all.sample(rand(30..50))
   )
 end
-
-# Cases we should cover with seeds
-# User with no resources, no lists, no groups
-# User with no resources, one list, no groups
-# User with resource, list, group
-# User with one group, no list
-
-# Group with all users, one list
-# Group with 2 users, no list
-
-# Resource belongs to a user, and two lists
-# Resource belongs to no user, and two lists
-# Resource belongs to one list
-
-# User's list
-# User's list
-# Group's list


### PR DESCRIPTION
Added tagging support using the [`acts_as_taggable_on`](https://github.com/mbleigh/acts-as-taggable-on) gem. Enabled tagging for `User`, `Resource`, `List`, and `Group`.