### PR TITLE
Don't set a default username in the db

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -21,8 +21,10 @@ default: &default
   # http://guides.rubyonrails.org/configuring.html#database-pooling
   pool: 5
   host: localhost
-  username: root
   database: commons
+
+production:
+  <<: *default
 
 development:
   <<: *default
@@ -34,8 +36,3 @@ development:
 test:
   <<: *default
   database: commonstest
-
-# TODO: Do we need to include this?
-# production:
-#   <<: *default
-#   database: db/production.sqlite3


### PR DESCRIPTION
Reason for Change
=================
* Usernames are not required for postgres databases, particularly in development.
* Also: I never set a `root` user for for my development/test databases since it's not necessary.
* Also YAML doesn't support overriding when inheriting, because it's basically just merging hashes.

Changes
=======
* Remove the `root` database username from the default configuration.
* Add it to the `production` group.

Recommended Reviewers
=====================
@ptrikutam