### PR TITLE
Limit running rubocop to the test environment

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -2,5 +2,8 @@ require_relative 'config/application'
 
 Rails.application.load_tasks
 
-task(:default).clear
-task default: %w(rubocop spec)
+task default: :spec
+
+if Rails.env.test?
+  task(:default).prerequisites << task(:rubocop)
+end

--- a/circle.yml
+++ b/circle.yml
@@ -50,7 +50,7 @@ machine:
 ## Customize test commands
 test:
   override:
-    - bundle exec rspec spec
+    - bundle exec rspec
 #   post:
 #     - bundle exec rake jasmine:ci: # add an extra test type
 #         environment:


### PR DESCRIPTION
Reason for Change
=================
* The Heroku deploy step was breaking because the `rubocop` library is not in the `production` gem group.
* The options here are to make Rubocop run when we deploy (seems bad) or only run `rake rubocop` on default when we are in the test environment, which includes CI.

Changes
=======
* Set only `spec` as the default Raketask.
* Add `rubocop` to the default Raketask if we are in the `test` Rails environment only.

Minor
=====
* Use [the preferred Rake task format][1]
* Tell CI to run all RSpec tests, not just those in the `spec` directory. This is not critical now (all specs are in `/spec`) but it is unnecessarily specific and could cause problems later.

[1]: http://po-ru.com/diary/adding-to-the-default-rake-task/