### PR TITLE
Limit the rubocop rake task to test only

### DIFF
--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -1,9 +1,11 @@
-require 'rubocop/rake_task'
+if Rails.env.test?
+  require 'rubocop/rake_task'
 
-desc 'Run Rubocop to lint code and enforce style guide'
+  desc 'Run Rubocop to lint code and enforce style guide'
 
-task :rubocop do
-  require 'rubocop'
-  cli = RuboCop::CLI.new
-  cli.run(%w(--rails))
+  task :rubocop do
+    require 'rubocop'
+    cli = RuboCop::CLI.new
+    cli.run(%w(--rails))
+  end
 end


### PR DESCRIPTION
Reason for Change
=================
* Heroku still breaking with this error:

```
remote: sh: 2: Syntax error: Unterminated quoted string
```

* This feels like an environment variable issue but I wanted to isolate it so I'm going to try this first.
* Could be something with trying to load the `rubocop.rake` task under production...

Changes
=======
* Gate the rake task to only `:test`, just like the default bit.