### PR TITLE
Fix db seeds script

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -13,7 +13,7 @@
 # - Group's list
 
 # Create users
-5.times do
+5.times do |n|
   User.create(
     email: "user#{n}@greencommons.org",
     password: 'thecommons'


### PR DESCRIPTION
# Reason for Change
- `seeds.rb` is broken:

```
$ heroku run 'rake db:seed' -a greencommons
Running rake db:seed on ⬢ greencommons... up, run.3231 (Hobby)
D, [2016-11-04T23:57:28.504146 #3] DEBUG -- :   ActiveRecord::SchemaMigration Load (1.6ms)  SELECT "schema_migrations".* FROM "schema_migrations"
rake aborted!
NameError: undefined local variable or method `n' for main:Object
/app/db/seeds.rb:18:in `block in <top (required)>'
/app/db/seeds.rb:16:in `times'
```

# Changes
- Added the `n` variable back into the script.