### PR TITLE
Add elasticsearch installation to setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -3,11 +3,15 @@ require 'pathname'
 require 'fileutils'
 include FileUtils
 
-# path to your application root.
+# Path to your application root.
 APP_ROOT = Pathname.new File.expand_path('../../', __FILE__)
 
 def system!(*args)
   system(*args) || abort("\n== Command #{args} failed ==")
+end
+
+def this_is_not_installed?(cli_name)
+  !system("which #{cli_name} > /dev/null 2>&1")
 end
 
 chdir APP_ROOT do
@@ -19,12 +23,20 @@ chdir APP_ROOT do
     system! 'cp .env.sample .env'
   end
 
-  # Check for tools that need to be installed
-  %w(foreman heroku).each do |tool|
-    unless system("which #{tool}")
-      puts "#{tool} INSTALLED"
-      abort("\n== #{tool} not installed, aborting ==")
-    end
+  if this_is_not_installed?('foreman')
+    puts '== Installing foreman =='
+    system('gem install foreman')
+  end
+
+  if this_is_not_installed?('heroku')
+    puts "== Installing Heroku's Command Line Tool =="
+    system('brew install heroku')
+  end
+
+  if this_is_not_installed?('elasticsearch')
+    puts "== Installing ElasticSearch =="
+    puts "NOTE! You must be running ElasticSearch for the app to work."
+    system('brew install elasticsearch')
   end
 
   # Add binstubs to PATH via export PATH=".git/safe/../../bin:$PATH" in ~/.zshenv

--- a/config/initializers/elasticsearch.rb
+++ b/config/initializers/elasticsearch.rb
@@ -1,1 +1,3 @@
-Elasticsearch::Model.client = Elasticsearch::Client.new url: ENV.fetch('BONSAI_URL', 'http://localhost:9200')
+Elasticsearch::Model.client = Elasticsearch::Client.new(
+  url: ENV.fetch('BONSAI_URL', 'http://localhost:9200')
+)


### PR DESCRIPTION
Reason for Change
=================
* Elastic Search is now a hard dependency of this application.
* As such, we should help the user install it, if they haven't done so already.
* https://github.com/greencommons/commons/issues/30

Changes
=======
* Add a step to check for an `elasticsearch` binary, install if it doesn't exist.
* Instead of aborting when some tools are not installed, install them for the user.

Minor
=====
* Avoid echoing to the shell by piping to `/dev/null`.
* Capitalize comments.