### PR TITLE
Add elasticsearch to the Procfile.dev

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+search: elasticsearch

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We follow [thoughtbot's git guide](https://github.com/thoughtbot/guides/tree/mas
 Setup (OS X)
 ------------
 
-#### Perequisites
+#### Prerequisites
 
 - [Heroku Toolbelt]
 - Ruby, >= 2.3.1


### PR DESCRIPTION
Reason for Change
=================
* In development, we will need elasticsearch to be running for the app to function and tests to pass.
* https://github.com/greencommons/commons/issues/24

Changes
=======
* Add a line to the `Procfile.dev` to run elasticsearch.

Minor
-----
* Split long line in the initializer.