### PR TITLE
Add a bummr for more easily updating gems

### DIFF
--- a/.bummr-build.sh
+++ b/.bummr-build.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,11 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 
 group :development do
+  gem 'bummr'
   gem 'bundler-audit'
   gem 'listen', '~> 3.0.5'
-  gem 'pry-rails'
   gem 'pry-coolline'
+  gem 'pry-rails'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,6 +45,9 @@ GEM
     awesome_print (1.7.0)
     bcrypt (3.1.11)
     builder (3.2.2)
+    bummr (0.1.6)
+      rainbow
+      thor
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
@@ -240,6 +243,7 @@ PLATFORMS
 DEPENDENCIES
   acts-as-taggable-on (~> 4.0)
   awesome_print
+  bummr
   bundler-audit
   byebug
   database_cleaner

--- a/README.md
+++ b/README.md
@@ -62,3 +62,20 @@ We test using [rspec]/[rspec-rails]. You can run the test suite by running:
 
 [rspec]: https://github.com/rspec/rspec
 [rspec-rails]: https://github.com/rspec/rspec-rails
+
+Updating Gems
+-------------
+
+We should update gems regularly for security and bugfix reasons.
+We use a tool called [bummr] to update the dependencies for us.
+It will update each gem individually, then run the tests and if any fail,
+use `git bisect` to figure out which one is the problem.
+
+Every [week or so], run this command:
+
+```
+bummr update
+```
+
+[bummr]: https://github.com/lpender/bummr
+[week or so]: http://adarsh.io/save-money-and-be-happier-by-updating-your-gems-every-monday-morning/


### PR DESCRIPTION
Reason for Change
=================
* Gems should stay updated.
* Sometimes, they break the app.
* [`bummr`][1] helps us update the gems and figure out which ones break the app.

[1]: https://github.com/lpender/bummr

Changes
=======
* Add the gem
* Add a `.bummr-build.sh` file, which is how it knows how to run the tests.
* Describe the change in the `README.md`.