### PR TITLE
Run Search Index actions asynchronously

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,5 +45,9 @@ RSpec/DescribedClass:
   Enabled: false
 RSpec/FilePath:
   Enabled: false
+RSpec/ExampleLength:
+  Description: Checks for long examples.
+  Enabled: true
+  Max: 20
 RSpec/FilePath:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -12,14 +12,13 @@ gem 'pg'
 gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem 'sass-rails', '~> 5.0'
+gem 'sidekiq'
 gem 'uglifier', '>= 1.3.0'
 
 group :development do
   gem 'bummr'
   gem 'bundler-audit'
   gem 'listen', '~> 3.0.5'
-  gem 'pry-coolline'
-  gem 'pry-rails'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
   gem 'web-console'
@@ -27,10 +26,11 @@ end
 
 group :development, :test do
   gem 'awesome_print'
-  gem 'byebug', platform: :mri
+  gem 'climate_control'
   gem 'database_cleaner'
   gem 'dotenv'
   gem 'factory_girl_rails'
+  gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.5'
   gem 'rubocop'
   gem 'rubocop-rspec'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,11 +51,12 @@ GEM
     bundler-audit (0.5.0)
       bundler (~> 1.2)
       thor (~> 0.18)
-    byebug (9.0.5)
+    byebug (9.0.6)
+    climate_control (0.0.3)
+      activesupport (>= 3.0)
     coderay (1.1.1)
     concurrent-ruby (1.0.2)
-    coolline (0.5.0)
-      unicode_utils (~> 1.4)
+    connection_pool (2.2.1)
     database_cleaner (1.5.3)
     debug_inspector (0.0.2)
     devise (4.2.0)
@@ -127,12 +128,13 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    pry-coolline (0.2.5)
-      coolline (~> 0.5)
-    pry-rails (0.3.4)
-      pry (>= 0.9.10)
+    pry-byebug (3.4.0)
+      byebug (~> 9.0)
+      pry (~> 0.10)
     puma (3.6.0)
     rack (2.0.1)
+    rack-protection (1.5.3)
+      rack
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (5.0.0.1)
@@ -163,6 +165,7 @@ GEM
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
       ffi (>= 0.5.0)
+    redis (3.3.1)
     request_store (1.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
@@ -205,6 +208,11 @@ GEM
     shoulda-context (1.2.1)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
+    sidekiq (4.2.6)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (~> 3.2, >= 3.2.1)
     slop (3.6.0)
     spring (1.7.2)
     spring-watcher-listen (2.0.0)
@@ -225,7 +233,6 @@ GEM
     uglifier (3.0.2)
       execjs (>= 0.3.0, < 3)
     unicode-display_width (1.1.1)
-    unicode_utils (1.4.0)
     warden (1.2.6)
       rack (>= 1.0)
     web-console (3.3.1)
@@ -245,7 +252,7 @@ DEPENDENCIES
   awesome_print
   bummr
   bundler-audit
-  byebug
+  climate_control
   database_cleaner
   devise
   dotenv
@@ -256,8 +263,7 @@ DEPENDENCIES
   listen (~> 3.0.5)
   paper_trail
   pg
-  pry-coolline
-  pry-rails
+  pry-byebug
   puma (~> 3.0)
   rails (~> 5.0.0, >= 5.0.0.1)
   rspec-rails (~> 3.5)
@@ -265,6 +271,7 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (~> 5.0)
   shoulda
+  sidekiq
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)

--- a/app/jobs/indexer_job.rb
+++ b/app/jobs/indexer_job.rb
@@ -1,0 +1,24 @@
+class IndexerJob
+  include Sidekiq::Worker
+  sidekiq_options queue: 'elasticsearch', retry: true
+
+  def perform(action, model_name, id)
+    @action = action
+    @id = id
+    @model_name = model_name
+
+    record.__elasticsearch__.send(index_action)
+  end
+
+  private
+
+  attr_reader :action, :id, :model_name
+
+  def record
+    model_name.constantize.find(id)
+  end
+
+  def index_action
+    "#{action}_document".to_sym
+  end
+end

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,6 +1,5 @@
 class Resource < ApplicationRecord
   include Elasticsearch::Model
-  include Elasticsearch::Model::Callbacks
 
   RESOURCE_TYPES = {
     article: 0,
@@ -20,4 +19,7 @@ class Resource < ApplicationRecord
   has_and_belongs_to_many :lists
 
   validates :title, :resource_type, presence: true
+
+  after_save { SearchIndex.add(self) }
+  after_destroy { SearchIndex.remove(self) }
 end

--- a/app/service/search_index.rb
+++ b/app/service/search_index.rb
@@ -1,0 +1,23 @@
+class SearchIndex
+  def self.add(record)
+    if search_index_callbacks_enabled?
+      IndexerJob.perform_async(:index, record.id)
+    end
+  end
+
+  def self.remove(record)
+    if search_index_callbacks_enabled?
+      IndexerJob.perform_async(:delete, record.id)
+    end
+  end
+
+  def self.search_index_callbacks_enabled?
+    Rails.logger.tagged('ELASTICSEARCH') do
+      Rails.logger.warn(
+        "Note: ElasticSearch's Model callbacks have been disabled"
+      )
+    end
+
+    ENV.fetch('ENABLE_SEARCH_INDEX_CALLBACKS', true) != 'false'
+  end
+end

--- a/spec/factories/lists.rb
+++ b/spec/factories/lists.rb
@@ -1,6 +1,6 @@
 FactoryGirl.define do
   factory :list do
     name  { Faker::Lorem.word }
-    owner { FactoryGirl.create(:user) }
+    owner { create(:user) }
   end
 end

--- a/spec/jobs/indexer_job_spec.rb
+++ b/spec/jobs/indexer_job_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe IndexerJob, :worker do
+  describe '.perform', search_indexing_callbacks: false do
+    it 'adds a new record to the search index' do
+      travel_to(Time.zone.now) do
+        record = create(:resource)
+        allow(Elasticsearch::Model.client).to receive(:index)
+
+        IndexerJob.perform_async(:index, record.class, record.id)
+
+        expect(Elasticsearch::Model.client).to have_received(:index).
+          with(
+            index: 'resources',
+            type: 'resource',
+            id: record.id,
+            body: record.__elasticsearch__.as_indexed_json,
+          )
+      end
+    end
+
+    it 'removes an existing record in the search index' do
+      record = create(:resource)
+      allow(Elasticsearch::Model.client).to receive(:delete)
+
+      IndexerJob.perform_async(:delete, record.class, record.id)
+
+      expect(Elasticsearch::Model.client).to have_received(:delete).
+        with(
+          index: 'resources',
+          type: 'resource',
+          id: record.id,
+        )
+    end
+  end
+end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe Group, type: :model do
+RSpec.describe Group do
   describe 'Validations' do
     it 'is valid with valid attributes' do
-      group = FactoryGirl.create(:group)
+      group = create(:group)
 
       expect(group).to be_valid
     end
@@ -12,13 +12,13 @@ RSpec.describe Group, type: :model do
   end
 
   describe '#resources' do
-    let(:r1) { FactoryGirl.create(:resource) }
-    let(:r2) { FactoryGirl.create(:resource) }
-    let(:l1) { FactoryGirl.create(:list, resources: [r1, r2]) }
-    let(:l2) { FactoryGirl.create(:list, resources: [r2]) }
+    let(:r1) { create(:resource) }
+    let(:r2) { create(:resource) }
+    let(:l1) { create(:list, resources: [r1, r2]) }
+    let(:l2) { create(:list, resources: [r2]) }
 
     it 'returns a unique list of resources' do
-      group = FactoryGirl.create(:group)
+      group = create(:group)
 
       group.update(lists: [l1, l2])
 

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,11 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe List, type: :model do
-  list = FactoryGirl.create(:list)
-
+RSpec.describe List do
   describe 'Validations' do
     it 'is valid with valid attributes' do
-      list = FactoryGirl.create(:list)
+      list = create(:list)
 
       expect(list).to be_valid
     end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe Resource, type: :model do
+RSpec.describe Resource do
   describe 'Validations' do
     it 'is valid with valid attributes' do
-      resource = FactoryGirl.build(:resource)
+      resource = build(:resource)
 
       expect(resource).to be_valid
     end
@@ -15,5 +15,28 @@ RSpec.describe Resource, type: :model do
   describe 'Associations' do
     it { is_expected.to belong_to(:user) }
     it { is_expected.to have_and_belong_to_many(:lists) }
+  end
+
+  describe 'Callbacks' do
+    describe 'after_save' do
+      it 'adds the resource to the search index after creation' do
+        allow(SearchIndex).to receive(:add)
+
+        resource = create(:resource)
+
+        expect(SearchIndex).to have_received(:add).with(resource)
+      end
+    end
+
+    describe 'after_destroy' do
+      it 'removes the resource from the search index after deletion' do
+        allow(SearchIndex).to receive(:remove)
+
+        resource = create(:resource)
+        resource.destroy
+
+        expect(SearchIndex).to have_received(:remove).with(resource)
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,9 +1,9 @@
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
+RSpec.describe User do
   describe 'Validations' do
     it 'is valid with valid attributes' do
-      user = FactoryGirl.build(:user)
+      user = build(:user)
 
       expect(user).to be_valid
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,53 +5,24 @@ require File.expand_path('../../config/environment', __FILE__)
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
-# Add additional requires below this line. Rails is not loaded until this point!
-
-# Requires supporting ruby files with custom matchers and macros, etc, in
-# spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
-# run as spec files by default. This means that files in spec/support that end
-# in _spec.rb will both be required and run as specs, causing the specs to be
-# run twice. It is recommended that you do not name files matching this glob to
-# end with _spec.rb. You can configure this pattern with the --pattern
-# option on the command line or in ~/.rspec, .rspec or `.rspec-local`.
-#
-# The following line is provided for convenience purposes. It has the downside
-# of increasing the boot-up time by auto-requiring all files in the support
-# directory. Alternatively, in the individual `*_spec.rb` files, manually
-# require only the support files necessary.
-#
-# Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
-
-# Checks for pending migration and applies them before tests are run.
-# If you are not using ActiveRecord, you can remove this line.
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
+  config.include ActiveSupport::Testing::TimeHelpers
+  config.filter_rails_from_backtrace!
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
-
-  # If you're not using ActiveRecord, or you'd prefer not to run each of your
-  # examples within a transaction, remove the following line or assign false
-  # instead of true.
+  config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
 
-  # RSpec Rails can automatically mix in different behaviours to your tests
-  # based on their file location, for example enabling you to call `get` and
-  # `post` in specs under `spec/controllers`.
-  #
-  # You can disable this behaviour by removing the line below, and instead
-  # explicitly tag your specs with their type, e.g.:
-  #
-  #     RSpec.describe UsersController, :type => :controller do
-  #       # ...
-  #     end
-  #
-  # The different available types are documented in the features, such as in
-  # https://relishapp.com/rspec/rspec-rails/docs
-  config.infer_spec_type_from_file_location!
+  config.around(:each, search_indexing_callbacks: false) do |example|
+    ClimateControl.modify(ENABLE_SEARCH_INDEX_CALLBACKS: 'false') do
+      example.run
+    end
+  end
 
-  # Filter lines from Rails gems in backtraces.
-  config.filter_rails_from_backtrace!
-  # arbitrary gems may also be filtered via:
-  # config.filter_gems_from_backtrace("gem name")
+  config.around(:each, :worker) do |example|
+    Sidekiq::Testing.inline! do
+      example.run
+    end
+  end
 end

--- a/spec/service/search_index_spec.rb
+++ b/spec/service/search_index_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe SearchIndex do
+  describe '.add' do
+    it 'enqueues a job to include the record in the search index' do
+      allow(IndexerJob).to receive(:perform_async)
+      resource = build_stubbed(:resource)
+
+      SearchIndex.add(resource)
+
+      expect(IndexerJob).to have_received(:perform_async).
+        with(:index, resource.id)
+    end
+
+    context 'if index callbacks disabled', search_indexing_callbacks: false do
+      it 'does not add to the search index' do
+        allow(IndexerJob).to receive(:perform_async)
+        resource = build_stubbed(:resource)
+
+        SearchIndex.add(resource)
+
+        expect(IndexerJob).not_to have_received(:perform_async).
+          with(:index, resource.id)
+      end
+    end
+  end
+
+  describe '.remove' do
+    it 'removes the resource from the search index after deletion' do
+      allow(IndexerJob).to receive(:perform_async)
+      resource = build_stubbed(:resource)
+
+      SearchIndex.remove(resource)
+
+      expect(IndexerJob).to have_received(:perform_async).
+        with(:delete, resource.id)
+    end
+
+    context 'if index callbacks disabled', search_indexing_callbacks: false do
+      it 'does not remove the resource from the index' do
+        allow(IndexerJob).to receive(:perform_async)
+        resource = build_stubbed(:resource)
+
+        SearchIndex.remove(resource)
+
+        expect(IndexerJob).not_to have_received(:perform_async).
+          with(:delete, resource.id)
+      end
+    end
+  end
+
+  describe '.search_index_callbacks_enabled?' do
+    context 'if index callbacks disabled', search_indexing_callbacks: false do
+      it 'is false' do
+        allow(IndexerJob).to receive(:perform_async)
+        allow(Rails.logger).to receive(:warn)
+
+        expect(SearchIndex.search_index_callbacks_enabled?).to be_falsey
+      end
+
+      it 'logs a warning' do
+        allow(IndexerJob).to receive(:perform_async)
+        resource = build_stubbed(:resource)
+        allow(Rails.logger).to receive(:warn)
+
+        SearchIndex.remove(resource)
+
+        expect(Rails.logger).to have_received(:warn).with(/callbacks.+disabled/)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
+require 'factory_girl_rails'
+require 'sidekiq/testing'
+
 RSpec.configure do |config|
+  config.include FactoryGirl::Syntax::Methods
+
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end


### PR DESCRIPTION
Reason for Change
=================
* When we perform CRUD actions on an AR model, we want to subsequently update the search index to keep everything in sync.
* That can delay the request cycle, so we should perform those activities in the background.

Changes
=======
* Add custom callbacks instead of the stock ElasticSearch ones.
* Send modified records to a `SearchIndex` service class to abstract away everything about ElasticSearch. Let it enqueue jobs or whatever it wants.
* Create a general job class to add/remove records from the search index. Built it to allow for any type of AR record with `ElasticSearch::Model` mixed in.
* Add `sidekiq` gem for background job processing.
* Add a way to disable the callbacks via `ENV`.

Minor
=====
* Add [`climate_control`] gem for temporarily modifying `ENV` in tests.
* Use [`pry-byebug`] instead of other pry/byebug variants.
* Add an RSpec tag to disable search indexing callbacks for tests.
* Add an RSpec tag to exercise background jobs inline.
* Allow Rubocop to have longer specs than 5 lines
* Use implicit FactoryGirl calls (e.g. no need for `FactoryGirl.` all the time)
* [Let RSpec infer the spec type based on the folder][1]. No need for `type: model`.

[1]: https://www.relishapp.com/rspec/rspec-rails/v/3-5/docs/directory-structure

[`climate_control`]: https://github.com/thoughtbot/climate_control
[`pry-byebug`]: https://github.com/deivid-rodriguez/pry-byebug