### PR TITLE
Correct Sidekiq configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@
 
 # Ingore those damn Mac OS files
 .DS_Store
+
+# Ignore Redis database
+dump.rdb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ AllCops:
     - 'bin/**/*'
     - 'db/**/*'
     - 'config/initializers/devise.rb'
+    - 'Guardfile'
 
 # Ruby Style
 Metrics/LineLength:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,5 +50,7 @@ RSpec/ExampleLength:
   Description: Checks for long examples.
   Enabled: true
   Max: 20
-RSpec/FilePath:
-  Enabled: false
+RSpec/MultipleExpectations:
+  Description: Checks if examples contain too many `expect` calls.
+  Enabled: true
+  Max: 3

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.3.2'
 
 gem 'acts-as-taggable-on', '~> 4.0'
 gem 'bootstrap-sass', '~> 3.3.7'
+gem 'capybara-webkit'
 gem 'devise'
 gem 'elasticsearch-model'
 gem 'elasticsearch-rails'
@@ -15,6 +16,7 @@ gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
+gem 'slim'
 gem 'uglifier', '>= 1.3.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       tzinfo (~> 1.1)
     acts-as-taggable-on (4.0.0)
       activerecord (>= 4.0)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     ast (2.3.0)
     autoprefixer-rails (6.5.3)
@@ -57,6 +59,16 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (9.0.6)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    capybara-webkit (1.11.1)
+      capybara (>= 2.3.0, < 2.8.0)
+      json
     climate_control (0.0.3)
       activesupport (>= 3.0)
     coderay (1.1.1)
@@ -126,6 +138,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.0.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -164,6 +177,7 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
+    public_suffix (2.0.4)
     puma (3.6.0)
     rack (2.0.1)
     rack-protection (1.5.3)
@@ -247,6 +261,9 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
+    slim (3.0.7)
+      temple (~> 0.7.6)
+      tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     spring (2.0.0)
       activesupport (>= 4.2)
@@ -260,6 +277,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temple (0.7.7)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -278,6 +296,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -288,6 +308,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.7)
   bummr
   bundler-audit
+  capybara-webkit
   climate_control
   database_cleaner
   devise
@@ -310,6 +331,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda
   sidekiq
+  slim
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,4 @@
 web: bundle exec puma -C config/puma.rb
 worker: bundle exec sidekiq -C config/sidekiq.yml
 search: elasticsearch
+redis: redis-server

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,2 +1,3 @@
 web: bundle exec puma -C config/puma.rb
+worker: bundle exec sidekiq -C config/sidekiq.yml
 search: elasticsearch

--- a/README.md
+++ b/README.md
@@ -31,12 +31,16 @@ Setup (OS X)
 - [Heroku Toolbelt]
 - Ruby, >= 2.3.2
 - Postgres
+- QT ([install instructions here])
+- [XCode] 8.0+
 
 You can install most of the above with [Homebrew]. For Postgres, @ptrikutam uses [Postgres.app] but you're welcome to set it up however you like.
 
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
 [Homebrew]: http://brew.sh/
 [Postgres.app]: http://postgresapp.com/
+[install instructions here]: https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#macos-sierra-1012
+[XCode]: https://developer.apple.com/xcode/
 
 #### Setting up the repository
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,5 @@
+class SearchController < ApplicationController
+  def new
+    @results = Resource.search(params[:query])
+  end
+end

--- a/app/jobs/indexer_job.rb
+++ b/app/jobs/indexer_job.rb
@@ -7,6 +7,12 @@ class IndexerJob
     @id = id
     @model_name = model_name
 
+    Rails.logger.tagged('ELASTICSEARCH') do
+      Rails.logger.warn(
+        "Hey! Performing a #{action} on a #{model_name} record with id# #{record.id}"
+      )
+    end
+
     record.__elasticsearch__.send(index_action)
   end
 

--- a/app/service/search_index.rb
+++ b/app/service/search_index.rb
@@ -1,23 +1,27 @@
 class SearchIndex
   def self.add(record)
     if search_index_callbacks_enabled?
-      IndexerJob.perform_async(:index, record.id)
+      IndexerJob.perform_async(:index, record.class.name, record.id)
     end
   end
 
   def self.remove(record)
     if search_index_callbacks_enabled?
-      IndexerJob.perform_async(:delete, record.id)
+      IndexerJob.perform_async(:delete, record.class.name, record.id)
     end
   end
 
   def self.search_index_callbacks_enabled?
-    Rails.logger.tagged('ELASTICSEARCH') do
-      Rails.logger.warn(
-        "Note: ElasticSearch's Model callbacks have been disabled"
-      )
+    enabled = ENV.fetch('ENABLE_SEARCH_INDEX_CALLBACKS', true) != 'false'
+
+    unless enabled
+      Rails.logger.tagged('ELASTICSEARCH') do
+        Rails.logger.warn(
+          "Note: ElasticSearch's Model callbacks have been disabled"
+        )
+      end
     end
 
-    ENV.fetch('ENABLE_SEARCH_INDEX_CALLBACKS', true) != 'false'
+    enabled
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
         <% if user_signed_in? %>
           <%= link_to('Logout', destroy_user_session_path) %>
         <% else %>
-          <%= link_to 'Sign In', new_user_session_path  %> | <%= link_to "Sign Up", new_user_registration_path %>  
+          <%= link_to 'Sign In', new_user_session_path  %> | <%= link_to "Sign Up", new_user_registration_path %>
         <% end %>
       </div>
 
@@ -24,7 +24,7 @@
       <% if alert.present? %>
         <p class="alert"><%= "ALERT: #{alert}" %></p>
       <% end %>
-    
+
       <%= yield %>
     </div>
   </body>

--- a/app/views/search/new.html.slim
+++ b/app/views/search/new.html.slim
@@ -1,0 +1,21 @@
+h1.title
+  | Search#new
+
+.customer-search-form
+  = form_for new_search_path, method: :get do |form|
+    = form.label 'Search for'
+    p
+    = text_field_tag :query, params[:query]
+    = submit_tag 'Go', name: nil
+
+ul.search-results
+  - @results.each do |result|
+    h2.Result
+
+    li.search-result
+      h3.title
+        = result.title
+      h5.author-name
+        = result.metadata.fetch(:author, 'No Author Found')
+      h5.year-published
+        = result.metadata.fetch(:year_published, 'Year Published Unknown')

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Green Commons</h1>
-<p>Welcome to Green Commons.</p>

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,14 @@
+Sidekiq::Logging.logger = Rails.logger
+Sidekiq::Logging.logger.level = Logger::DEBUG
+
+Sidekiq.configure_server do |config|
+  config.redis = {
+    url: ENV.fetch('REDIS_URL', 'redis://localhost:6379'),
+  }
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = {
+    url: ENV.fetch('REDIS_URL', 'redis://localhost:6379'),
+  }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
+  root 'search#new'
+
+  resources :search, only: [:new]
+
   devise_for :users
-  root 'static_pages#index'
 
   if Rails.env.development?
     require 'sidekiq/web'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
   devise_for :users
-  # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   root 'static_pages#index'
+
+  if Rails.env.development?
+    require 'sidekiq/web'
+    mount Sidekiq::Web => '/sidekiq'
+  end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,9 @@
+# https://github.com/mperham/sidekiq/wiki/Advanced-Options#the-sidekiq-configuration-file
+concurrency: 5
+staging:
+  :concurrency: 10
+production:
+  :concurrency: 20
+:queues:
+  - 'default'
+  - ['elasticsearch', 2]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 # https://github.com/mperham/sidekiq/wiki/Advanced-Options#the-sidekiq-configuration-file
-concurrency: 5
+:concurrency: 1
 staging:
   :concurrency: 10
 production:

--- a/db/migrate/20161130200617_change_resource_metadata_to_required.rb
+++ b/db/migrate/20161130200617_change_resource_metadata_to_required.rb
@@ -1,0 +1,11 @@
+class ChangeResourceMetadataToRequired < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :resources, :metadata
+    add_column :resources, :metadata, :jsonb, null: false, default: {}
+  end
+
+  def down
+    remove_column :resources, :metadata
+    add_column :resources, :metadata, :json, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161022021350) do
+ActiveRecord::Schema.define(version: 20161130200617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,12 +51,12 @@ ActiveRecord::Schema.define(version: 20161022021350) do
   end
 
   create_table "resources", force: :cascade do |t|
-    t.string   "title",                     null: false
-    t.integer  "resource_type", default: 0, null: false
+    t.string   "title",                      null: false
+    t.integer  "resource_type", default: 0,  null: false
     t.integer  "user_id"
-    t.json     "metadata"
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.jsonb    "metadata",      default: {}, null: false
     t.index ["user_id"], name: "index_resources_on_user_id", using: :btree
   end
 

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching for resources', :worker do
+  context 'when searching by title' do
+    scenario 'users should see metadata for a resource when search' do
+      title = 'Silent Spring'
+      metadata = { author: 'Rachel Carson', year_published: 1962 }
+      resource = create(:resource, title: title, metadata: metadata)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: title
+        click_button 'Go'
+      end
+
+      expect(page).to have_text(resource.title)
+      expect(page).to have_text(resource.metadata[:author])
+      expect(page).to have_text(resource.metadata[:year_published])
+    end
+  end
+end

--- a/spec/service/search_index_spec.rb
+++ b/spec/service/search_index_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe SearchIndex do
       SearchIndex.add(resource)
 
       expect(IndexerJob).to have_received(:perform_async).
-        with(:index, resource.id)
+        with(:index, resource.class.name, resource.id)
     end
 
     context 'if index callbacks disabled', search_indexing_callbacks: false do
@@ -20,7 +20,7 @@ RSpec.describe SearchIndex do
         SearchIndex.add(resource)
 
         expect(IndexerJob).not_to have_received(:perform_async).
-          with(:index, resource.id)
+          with(:index, resource.class.name, resource.id)
       end
     end
   end
@@ -33,7 +33,7 @@ RSpec.describe SearchIndex do
       SearchIndex.remove(resource)
 
       expect(IndexerJob).to have_received(:perform_async).
-        with(:delete, resource.id)
+        with(:delete, resource.class.name, resource.id)
     end
 
     context 'if index callbacks disabled', search_indexing_callbacks: false do
@@ -44,7 +44,7 @@ RSpec.describe SearchIndex do
         SearchIndex.remove(resource)
 
         expect(IndexerJob).not_to have_received(:perform_async).
-          with(:delete, resource.id)
+          with(:delete, resource.class.name, resource.id)
       end
     end
   end


### PR DESCRIPTION
Reason for Change
=================
* Sidekiq jobs were not working correctly in development for a few reasons:
1. The interface for `IndexerJob` was not being used correctly.
1. There was no `worker` line in the `Procfiles`, so no workers were initiated. Hence, no jobs were being done.
1. Sidekiq was not initialized to use the correct redis connection URL.

Changes
=======
* Add configuration files and initializer for sidekiq for correct functioning.
* Add worker directives to foreman's `Procfile` manifest.
* Correct an interface error when creating `IndexerJob`s.

Minor
-----
* The "hey you've disabled the Elasticsearch callbacks" warning was inverted and incorrect. Fixed here.
* Add the sidekiq web monitoring page at `/sidekiq`, but only in development.

https://trello.com/c/f0lpURT0/27-add-a-search-field-and-return-a-result