### PR TITLE
Add Simple Search Results

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,5 +50,7 @@ RSpec/ExampleLength:
   Description: Checks for long examples.
   Enabled: true
   Max: 20
-RSpec/FilePath:
-  Enabled: false
+RSpec/MultipleExpectations:
+  Description: Checks if examples contain too many `expect` calls.
+  Enabled: true
+  Max: 3

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ ruby '2.3.2'
 
 gem 'acts-as-taggable-on', '~> 4.0'
 gem 'bootstrap-sass', '~> 3.3.7'
+gem 'capybara-webkit'
 gem 'devise'
 gem 'elasticsearch-model'
 gem 'elasticsearch-rails'
@@ -15,6 +16,7 @@ gem 'puma', '~> 3.0'
 gem 'rails', '~> 5.0.0', '>= 5.0.0.1'
 gem 'sass-rails', '~> 5.0'
 gem 'sidekiq'
+gem 'slim'
 gem 'uglifier', '>= 1.3.0'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       tzinfo (~> 1.1)
     acts-as-taggable-on (4.0.0)
       activerecord (>= 4.0)
+    addressable (2.5.0)
+      public_suffix (~> 2.0, >= 2.0.2)
     arel (7.1.4)
     ast (2.3.0)
     autoprefixer-rails (6.5.3)
@@ -57,6 +59,16 @@ GEM
       bundler (~> 1.2)
       thor (~> 0.18)
     byebug (9.0.6)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
+    capybara-webkit (1.11.1)
+      capybara (>= 2.3.0, < 2.8.0)
+      json
     climate_control (0.0.3)
       activesupport (>= 3.0)
     coderay (1.1.1)
@@ -126,6 +138,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    json (2.0.2)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -164,6 +177,7 @@ GEM
     pry-byebug (3.4.0)
       byebug (~> 9.0)
       pry (~> 0.10)
+    public_suffix (2.0.4)
     puma (3.6.0)
     rack (2.0.1)
     rack-protection (1.5.3)
@@ -247,6 +261,9 @@ GEM
       connection_pool (~> 2.2, >= 2.2.0)
       rack-protection (>= 1.5.0)
       redis (~> 3.2, >= 3.2.1)
+    slim (3.0.7)
+      temple (~> 0.7.6)
+      tilt (>= 1.3.3, < 2.1)
     slop (3.6.0)
     spring (2.0.0)
       activesupport (>= 4.2)
@@ -260,6 +277,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    temple (0.7.7)
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.5)
@@ -278,6 +296,8 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
@@ -288,6 +308,7 @@ DEPENDENCIES
   bootstrap-sass (~> 3.3.7)
   bummr
   bundler-audit
+  capybara-webkit
   climate_control
   database_cleaner
   devise
@@ -310,6 +331,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   shoulda
   sidekiq
+  slim
   spring
   spring-watcher-listen (~> 2.0.0)
   uglifier (>= 1.3.0)

--- a/README.md
+++ b/README.md
@@ -31,12 +31,16 @@ Setup (OS X)
 - [Heroku Toolbelt]
 - Ruby, >= 2.3.2
 - Postgres
+- QT ([install instructions here])
+- [XCode] 8.0+
 
 You can install most of the above with [Homebrew]. For Postgres, @ptrikutam uses [Postgres.app] but you're welcome to set it up however you like.
 
 [Heroku Toolbelt]: https://toolbelt.heroku.com/
 [Homebrew]: http://brew.sh/
 [Postgres.app]: http://postgresapp.com/
+[install instructions here]: https://github.com/thoughtbot/capybara-webkit/wiki/Installing-Qt-and-compiling-capybara-webkit#macos-sierra-1012
+[XCode]: https://developer.apple.com/xcode/
 
 #### Setting up the repository
 

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,5 @@
+class SearchController < ApplicationController
+  def new
+    @results = Resource.search(params[:query])
+  end
+end

--- a/app/jobs/indexer_job.rb
+++ b/app/jobs/indexer_job.rb
@@ -7,6 +7,12 @@ class IndexerJob
     @id = id
     @model_name = model_name
 
+    Rails.logger.tagged('ELASTICSEARCH') do
+      Rails.logger.warn(
+        "Hey! Performing a #{action} on a #{model_name} record with id# #{record.id}"
+      )
+    end
+
     record.__elasticsearch__.send(index_action)
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,7 +14,7 @@
         <% if user_signed_in? %>
           <%= link_to('Logout', destroy_user_session_path) %>
         <% else %>
-          <%= link_to 'Sign In', new_user_session_path  %> | <%= link_to "Sign Up", new_user_registration_path %>  
+          <%= link_to 'Sign In', new_user_session_path  %> | <%= link_to "Sign Up", new_user_registration_path %>
         <% end %>
       </div>
 
@@ -24,7 +24,7 @@
       <% if alert.present? %>
         <p class="alert"><%= "ALERT: #{alert}" %></p>
       <% end %>
-    
+
       <%= yield %>
     </div>
   </body>

--- a/app/views/search/new.html.slim
+++ b/app/views/search/new.html.slim
@@ -1,0 +1,21 @@
+h1.title
+  | Search#new
+
+.customer-search-form
+  = form_for new_search_path, method: :get do |form|
+    = form.label 'Search for'
+    p
+    = text_field_tag :query, params[:query]
+    = submit_tag 'Go', name: nil
+
+ul.search-results
+  - @results.each do |result|
+    h2.Result
+
+    li.search-result
+      h3.title
+        = result.title
+      h5.author-name
+        = result.metadata.fetch(:author, 'No Author Found')
+      h5.year-published
+        = result.metadata.fetch(:year_published, 'Year Published Unknown')

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,2 +1,0 @@
-<h1>Green Commons</h1>
-<p>Welcome to Green Commons.</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,9 @@
 Rails.application.routes.draw do
+  root 'search#new'
+
+  resources :search, only: [:new]
+
   devise_for :users
-  root 'static_pages#index'
 
   if Rails.env.development?
     require 'sidekiq/web'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 # https://github.com/mperham/sidekiq/wiki/Advanced-Options#the-sidekiq-configuration-file
-concurrency: 5
+:concurrency: 1
 staging:
   :concurrency: 10
 production:

--- a/db/migrate/20161130200617_change_resource_metadata_to_required.rb
+++ b/db/migrate/20161130200617_change_resource_metadata_to_required.rb
@@ -1,0 +1,11 @@
+class ChangeResourceMetadataToRequired < ActiveRecord::Migration[5.0]
+  def up
+    remove_column :resources, :metadata
+    add_column :resources, :metadata, :jsonb, null: false, default: {}
+  end
+
+  def down
+    remove_column :resources, :metadata
+    add_column :resources, :metadata, :json, null: true, default: nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161022021350) do
+ActiveRecord::Schema.define(version: 20161130200617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,12 +51,12 @@ ActiveRecord::Schema.define(version: 20161022021350) do
   end
 
   create_table "resources", force: :cascade do |t|
-    t.string   "title",                     null: false
-    t.integer  "resource_type", default: 0, null: false
+    t.string   "title",                      null: false
+    t.integer  "resource_type", default: 0,  null: false
     t.integer  "user_id"
-    t.json     "metadata"
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.jsonb    "metadata",      default: {}, null: false
     t.index ["user_id"], name: "index_resources_on_user_id", using: :btree
   end
 

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'Searching for resources', :worker do
+  context 'when searching by title' do
+    scenario 'users should see metadata for a resource when search' do
+      title = 'Silent Spring'
+      metadata = { author: 'Rachel Carson', year_published: 1962 }
+      resource = create(:resource, title: title, metadata: metadata)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: title
+        click_button 'Go'
+      end
+
+      expect(page).to have_text(resource.title)
+      expect(page).to have_text(resource.metadata[:author])
+      expect(page).to have_text(resource.metadata[:year_published])
+    end
+  end
+end


### PR DESCRIPTION
Reason for Change
=================
* We want to set up basic search functionality across Rails/Elasticsearch.
* Also, we'd like to establish one happy-path integration test to ensure the main functionality of the page is working.

Changes
=======
* Add documentation for setting up QT and XCode.
* Add capybara-webkit gem for a headless web driver to simulate rendering a full page.

Minor
=====
* Remove whitespace.
* Add `slim` gem for alternative templating.
* Delete placeholder static page.
* Reduce concurrency to keep up with database connection pool.
* Add logging for debugging
* Allow for up to 3 expectations in one test block.
* Remove duplicate `rspec-rubocop` configuration.

https://trello.com/c/f0lpURT0/27-add-a-search-field-and-return-a-result

![image](https://cloud.githubusercontent.com/assets/913757/20740279/8787cd36-b676-11e6-866c-c36e11365ba0.png)

