### PR TITLE
Style Auth Pages

### DIFF
--- a/app/helpers/devise_helper.rb
+++ b/app/helpers/devise_helper.rb
@@ -1,0 +1,15 @@
+module DeviseHelper
+  def devise_error_messages!
+    return '' if resource.errors.empty?
+
+    messages = resource.errors.full_messages.map { |msg| content_tag(:li, msg) }.join
+    html = <<-HTML
+    <div class="alert alert-danger"> <button type="button"
+    class="close" data-dismiss="alert">×</button>
+      #{messages}
+    </div>
+    HTML
+
+    html.html_safe
+  end
+end

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,0 +1,41 @@
+<div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3 ">
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
+    <%= devise_error_messages! %>
+    <fieldset>
+      <legend><h2>Sign up</h2></legend>
+      <div class="form-group">
+        <%= f.label :email, class: 'col-lg-2 control-label' %>
+        <div class="col-lg-10">
+          <%= f.email_field :email, autofocus: true, class: 'form-control', placeholder: 'Email', autocomplete: 'off' %>
+        </div>
+      </div>
+      <div class="form-group">
+        <%= f.label :password, class: 'col-lg-2 control-label' %>
+        <div class="col-lg-10">
+          <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'Password', autocomplete: 'off' %>
+          <% if @minimum_password_length %>
+            <small><em>(<%= @minimum_password_length %> characters minimum)</em></small>
+          <% end %>
+        </div>
+      </div>
+      <div class="form-group">
+        <label for="password_confirmation" class="col-lg-2 control-label">Confirm Password</label>
+        <div class="col-lg-10">
+          <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: 'Confirm Password', autocomplete: 'off' %>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-lg-10 col-lg-offset-2">
+          <%= f.submit "Sign Up", class: 'btn btn-lg btn-primary' %>
+        </div>
+      </div>
+    </fieldset>
+    <fieldset>
+      <div class="form-group">
+        <div class="col-lg-10 col-lg-offset-2">
+          <%= render "devise/shared/links" %>
+        </div>
+      </div>
+    </fieldset>
+  <% end %>
+</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,0 +1,45 @@
+<div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3 ">
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'form-horizontal' }) do |f| %>
+    <%= devise_error_messages! %>
+    <fieldset>
+      <legend><h2>Log in</h2></legend>
+      <div class="form-group">
+        <%= f.label :email, class: 'col-lg-2 control-label' %>
+        <div class="col-lg-10">
+          <%= f.email_field :email, autofocus: true, class: 'form-control', placeholder: 'Email', autocomplete: 'off' %>
+        </div>
+      </div>
+      <div class="form-group">
+        <%= f.label :password, class: 'col-lg-2 control-label' %>
+        <div class="col-lg-10">
+          <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: 'Password', autocomplete: 'off' %>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-lg-10 col-lg-offset-2">
+          <% if devise_mapping.rememberable? -%>
+            <div class="checkbox">
+              <label>
+                <%= f.check_box :remember_me %> Remember me?
+              </label>
+            </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class="col-lg-10 col-lg-offset-2">
+          <%= f.submit "Log in", class: 'btn btn-lg btn-primary' %>
+        </div>
+      </div>
+    </fieldset>
+    <fieldset>
+      <div class="form-group">
+        <div class="col-lg-10 col-lg-offset-2">
+          <%= render "devise/shared/links" %>
+        </div>
+      </div>
+    </fieldset>
+  <% end %>
+</div>
+
+

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,0 +1,25 @@
+<%- if controller_name != 'sessions' %>
+  <%= link_to "Log in", new_session_path(resource_name) %> |
+<% end -%>
+
+<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
+  <%= link_to "Sign up", new_registration_path(resource_name) %> |
+<% end -%>
+
+<%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
+  <%= link_to "Forgot your password?", new_password_path(resource_name) %>
+<% end -%>
+
+<%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
+  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
+  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+<% end -%>
+
+<%- if devise_mapping.omniauthable? %>
+  <%- resource_class.omniauth_providers.each do |provider| %>
+    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+  <% end -%>
+<% end -%>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,33 @@
+<% links = [] %>
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %> |
+  <% links.push(link_to "Log in", new_session_path(resource_name)) %>
 <% end -%>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %> |
+  <% links.push(link_to "Sign up", new_registration_path(resource_name)) %>
 <% end -%>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name) %>
+  <% links.push(link_to "Forgot your password?", new_password_path(resource_name)) %>
 <% end -%>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name) %><br />
+  <% links.push(link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name)) %>
 <% end -%>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name) %><br />
+  <% links.push(link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name)) %>
 <% end -%>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider) %><br />
+    <% links.push(link_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider)) %>
   <% end -%>
 <% end -%>
+
+<% links.each_with_index do |link, index| %>
+  <% unless index == 0 %>
+  |
+  <% end %>
+  <%= link %>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
   <head>
     <title>Commons</title>
     <%= csrf_meta_tags %>
-
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,7 @@
   <body>
     <%= render 'shared/nav' %>
     <div class="container">
-      <% if notice.present? %>
-        <p class="notice"> <%= "NOTICE: #{notice}" %></p>
-      <% end %>
-      <% if alert.present? %>
-        <p class="alert"><%= "ALERT: #{alert}" %></p>
-      <% end %>
-
+      <%= render 'shared/alerts' %>
       <%= yield %>
     </div>
 

--- a/app/views/shared/_alerts.html.erb
+++ b/app/views/shared/_alerts.html.erb
@@ -1,0 +1,17 @@
+<% if alert.present? %>
+  <div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
+    <div class="alert alert-warning alert-dismissable">
+      <a href="#" data-dismiss="alert" class="close">×</a>
+      <%= alert %>
+    </div>
+  </div>
+<% end %>
+
+<% if notice.present? %>
+  <div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
+    <div class="alert alert-info alert-dismissable">
+      <a href="#" data-dismiss="alert" class="close">×</a>
+      <%= notice %>
+    </div>
+  </div>
+<% end %>


### PR DESCRIPTION
# Reason for change

Our auth pages look terrible.

# Changes

- Using the devise generator, generate pages for the login and sign up pages
- Style them with Bootstrap form elements
- Add `shared/_alerts.html.erb` to nicely style alerts from the system in a bootstrap way (and remove the previous alert display code)
- Add `DeviseHelper` to help style devise errors in a bootstrap way