### PR TITLE
Add elasticsearch resource index deletion task

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ listed in the gem's `README.md`.
 
 [`guard-livereload`]: https://github.com/guard/guard-livereload
 
+Using the ElasticSearch Index
+-----------------------------
+
+Anything added, created, or deleted in the `Resource` model will automatically be indexed in ElasticSearch. If you'd like to recreate the index for any reason, you can use the following rake task:
+
+```
+bundle exec rake elasticsearch:reset_resource_index
+```
+
+This will delete the index and re-import all the records in the resources table.
+
 
 Testing
 -------

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,9 +1,11 @@
 namespace :elasticsearch do
-  desc 'Delete the "resource" index'
-  task :delete_resource_index do
+  desc 'Deletes the "resource" index and regenerates it with all records currently in Resource'
+  task :reset_resource_index do
     client = Elasticsearch::Client.new(
       url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log:true
     )
     client.indices.delete index: 'resources'
+    Resource.__elasticsearch__.create_index!
+    Resource.import
   end
 end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,0 +1,9 @@
+namespace :elasticsearch do
+  desc 'Delete the "resource" index'
+  task :delete_resource_index do
+    client = Elasticsearch::Client.new(
+      url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log:true
+    )
+    client.indices.delete index: 'resources'
+  end
+end


### PR DESCRIPTION
# Reason for change

There are many times we want to clear the index for ElasticSearch & start over. We want to create a utility task for this.

# Changes

- add `elasticsearch.rake` with the task to delete the "resources" index