### PR TITLE
Fix Sidekiq

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,8 @@ Rails.application.routes.draw do
 
   devise_for :users
 
-  if Rails.env.development?
+  # TODO: replace this with a check for admin user
+  if Rails.env.development? || ENV['ENABLE_SIDEKIQ_ADMIN']
     require 'sidekiq/web'
     mount Sidekiq::Web => '/sidekiq'
   end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,7 @@
 staging:
   :concurrency: 10
 production:
-  :concurrency: <%= ENV["SIDEKIQ_CONCURRENCY"] | 15 %>
+  :concurrency: <%= ENV['WORKER_CONCURRENCY'] | 15 %>
 :queues:
   - 'default'
   - ['elasticsearch', 2]

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,7 @@
 staging:
   :concurrency: 10
 production:
-  :concurrency: 20
+  :concurrency: <%= ENV["SIDEKIQ_CONCURRENCY"] | 15 %>
 :queues:
   - 'default'
   - ['elasticsearch', 2]


### PR DESCRIPTION
# Reason for Change

See #52. Sidekiq (and therefore, all indexing) is currently broken on production. We were [getting an error](https://gist.github.com/ptrikutam/dae56de24d756d36c5f18211117fe7c7) about a maximum number of clients reached for our worker process.

This is because the max number of connections for the Heroku Redis plan we're on is 20. According to [this comment](https://github.com/mperham/sidekiq/issues/117#issuecomment-5027680), the number of connections Sidekiq uses is concurrency + 2. We were over the limit by 2. This PR should reduce the concurrency, and allow us to change it as we like without having to make commits in the future.

# Changes

- For the sake of debugging, I'm changing `routes.rb` to see Sidekiq's web UI if we set an environment variable. This should be disabled most of the time and should be replaced with proper admin authentication in the future.
- Changing `sidekiq.yml` to either accept an env variable (`SIDEKIQ_CONCURRENCY`) or set the concurrency on production to 15.