### PR TITLE
Add styles to search page

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,5 +1,5 @@
 class SearchController < ApplicationController
   def new
-    @results = Resource.search(params[:query])
+    @results = params[:query].present? ? Resource.search(params[:query]) : []
   end
 end

--- a/app/views/search/new.html.slim
+++ b/app/views/search/new.html.slim
@@ -1,21 +1,31 @@
-h1.title
-  | Search#new
+.row
+  .col-sm-12.col-md-10.col-md-1.col-lg-8.col-lg-offset-2.text-center
+    = form_for new_search_path, method: :get, html: { class: 'form-horizontal customer-search-form' } do |form|
+      .form-group
+        .col-xs-8
+          = text_field_tag :query, params[:query], placeholder: 'Enter Search Term', class: 'form-control input-lg'
+          small
+            em Try searching for "wind," "green," or "river."
+        .col-xs-4
+          = submit_tag 'Search', name: nil, class: 'col-lg-12 btn btn-lg btn-primary'
 
-.customer-search-form
-  = form_for new_search_path, method: :get do |form|
-    = form.label 'Search for'
-    p
-    = text_field_tag :query, params[:query]
-    = submit_tag 'Go', name: nil
 
-ul.search-results
+- unless @results.empty?
   - @results.each do |result|
-    h2.Result
-
-    li.search-result
-      h3.title
-        = result.title
-      h5.author-name
-        = result.metadata.fetch(:author, 'No Author Found')
-      h5.year-published
-        = result.metadata.fetch(:year_published, 'Year Published Unknown')
+    .row
+      .well.col-sm-12
+        h3.text-center
+          = result.title
+        .dl-horizontal
+          dt
+            strong Record ID
+          dd
+            = result.id
+          dt
+            strong Author
+          dd
+            = result.metadata.fetch(:author, 'No Author Found')
+          dt
+            strong Published
+          dd
+            = result.metadata.fetch(:year_published, 'Year Published Unknown')

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature 'Searching for resources', :worker do
       visit new_search_path
       within('.customer-search-form') do
         fill_in 'query', with: title
-        click_button 'Go'
+        click_button 'Search'
       end
 
       expect(page).to have_text(resource.title)


### PR DESCRIPTION
# Reason for change

The search page could use a little visual enhancing.

# Changes

- Update `SearchController` to not search the Resource index unless there is a query parameter present.
- Update the search field & search results page to be a bit more bootstrap-y. These are by no means final styles but might look a little nicer for proof-of-concepts.

# Screenshots
- Before: https://cl.ly/1l44212n1n2C
- After: https://cl.ly/3e3F3K3y2p0H