### PR TITLE
Reduce logical complexity for search index jobs

### DIFF
--- a/app/service/search_index.rb
+++ b/app/service/search_index.rb
@@ -1,60 +1,51 @@
 class SearchIndex
-  def initialize(model_name:, id:, async: false)
+  def self.index_name(record)
+    "#{record.class.name.pluralize.downcase}-#{Rails.env}"
+  end
+
+  def self.log_elasticsearch_warning(message)
+    Rails.logger.tagged('ELASTICSEARCH') do
+      Rails.logger.warn(message)
+    end
+  end
+
+  def initialize(model_name:, id:)
     @model_name = model_name
     @id = id
-    @async = async
   end
 
   def add
-    if async
-      add_to_index_asynchronously
-    else
+    if search_index_callbacks_enabled?
       record = model_name.constantize.find(id)
       record.__elasticsearch__.index_document
+    else
+      log_callback_warning
     end
   end
 
   def remove
-    if async
-      remove_from_index_asynchronously
-    else
+    if search_index_callbacks_enabled?
       Elasticsearch::Model.client.delete(
         index: model_name.constantize.index_name,
         type: model_name.downcase,
         id: id,
       )
+    else
+      log_callback_warning
     end
   end
 
   private
 
-  attr_reader :async, :id, :model_name
-
-  def add_to_index_asynchronously
-    if search_index_callbacks_enabled?
-      AddToIndexJob.perform_async(model_name, id)
-    else
-      log_warning
-    end
-  end
-
-  def remove_from_index_asynchronously
-    if search_index_callbacks_enabled?
-      RemoveFromIndexJob.perform_async(model_name, id)
-    else
-      log_warning
-    end
-  end
+  attr_reader :id, :model_name
 
   def search_index_callbacks_enabled?
     ENV.fetch('ENABLE_SEARCH_INDEX_CALLBACKS', true) != 'false'
   end
 
-  def log_warning
-    Rails.logger.tagged('ELASTICSEARCH') do
-      Rails.logger.warn(
-        "Note: ElasticSearch's Model callbacks have been disabled"
-      )
-    end
+  def log_callback_warning
+    self.class.log_elasticsearch_warning(
+      "Note: ElasticSearch's Model callbacks have been disabled"
+    )
   end
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -20,38 +20,24 @@ RSpec.describe Resource do
   describe 'Callbacks' do
     describe 'after_save' do
       it 'adds the resource to the search index after creation' do
-        index = double('SearchIndex', add: true)
-        allow(SearchIndex).to receive(:new).and_return(index)
+        allow(AddToIndexJob).to receive(:perform_async)
 
         resource = create(:resource)
 
-        expect(SearchIndex).to have_received(:new).
-          with(
-            model_name: resource.class.name,
-            id: resource.id,
-            async: true,
-          )
-        expect(index).to have_received(:add)
+        expect(AddToIndexJob).to have_received(:perform_async).
+          with(resource.class.name, resource.id)
       end
     end
 
     describe 'after_destroy' do
       it 'removes the resource from the search index after deletion' do
         resource = create(:resource)
-        index = double('SearchIndex', remove: true)
-        allow(SearchIndex).to receive(:new).and_return(index)
-        id = resource.id
-        model_name = resource.class.name
+        allow(RemoveFromIndexJob).to receive(:perform_async)
 
         resource.destroy
 
-        expect(SearchIndex).to have_received(:new).
-          with(
-            model_name: model_name,
-            id: id,
-            async: true,
-          )
-        expect(index).to have_received(:remove)
+        expect(RemoveFromIndexJob).to have_received(:perform_async).
+          with(resource.class.name, resource.id)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,5 +12,6 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  config.example_status_persistence_file_path = 'tmp/examples.txt'
   config.shared_context_metadata_behavior = :apply_to_host_groups
 end


### PR DESCRIPTION
Reason for Change
=================
* See comment at https://github.com/greencommons/commons/pull/71#discussion_r91873393 :

> Would it make sense to have `RemoveFromIndexJob` directly here instead of having the path go `SearchIndex` -> `RemoveFromIndexJob` -> `SearchIndex`?

Yes.

Changes
=======
* Call the job enqueuing directly from the ActiveRecord model.
* Make the callback flag check and logging class-level methods.
* BUG: Correct index-name configuration error.

Minor
-----
* Set an RSpec file for storing metadata on the last suite run. This is useful for running flags like `--last-failure`.