### PR TITLE
ETL: Don't create duplicate records

### DIFF
--- a/lib/etl/load/create_new_resource_record.rb
+++ b/lib/etl/load/create_new_resource_record.rb
@@ -1,10 +1,28 @@
 class CreateNewResourceRecord
   def write(attributes)
-    record = Resource.create!(attributes)
+    @attributes = attributes
 
-    ap "Title: #{record.title}" # rubocop:disable Rails/Output
-    ap 'Metadata: ' # rubocop:disable Rails/Output
-    ap record.metadata # rubocop:disable Rails/Output
-    ap "Content: #{record.content.truncate(100)}" # rubocop:disable Rails/Output
+    if existing_record
+      ap "Title already in database: #{title}" # rubocop:disable Rails/Output
+    else
+      record = Resource.create!(attributes)
+
+      ap "Title: #{record.title}" # rubocop:disable Rails/Output
+      ap 'Metadata: ' # rubocop:disable Rails/Output
+      ap record.metadata # rubocop:disable Rails/Output
+      ap "Content: #{record.content.truncate(100)}" # rubocop:disable Rails/Output
+    end
+  end
+
+  private
+
+  attr_reader :attributes
+
+  def existing_record
+    Resource.find_by(title: title)
+  end
+
+  def title
+    attributes.fetch(:title)
   end
 end


### PR DESCRIPTION
Reason for Change
=================
* We don't want to duplicate records in the db when importing epubs.
* There isn't a good way to prevent downloading in the first place, unless we store the AWS S3 bucket/key in our db. This solution would depend on not renaming the files in the S3 bucket or moving them.

Changes
=======
* Only create the record if one does not already exist.