### PR TITLE
Add feature test for Authentication

### DIFF
--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -11,7 +11,7 @@
       .form-group
         = f.label :password, class: 'col-lg-2 control-label'
         .col-lg-10
-          = f.password_field :password, autocomplete: 'off', class: 'form-control', placeholder: 'Password', autocomplete: 'off'
+          = f.password_field :password, autocomplete: 'off', class: 'form-control', placeholder: 'Password'
       .form-group
         .col-lg-10.col-lg-offset-2
           - if devise_mapping.rememberable?

--- a/spec/feature/user_authenticates_spec.rb
+++ b/spec/feature/user_authenticates_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.feature 'Authentication' do
+  scenario 'users can login' do
+    create(:user, email: 'admin@greencommons.org', password: 'thecommons')
+    visit new_user_session_path
+
+    within('#new_user') do
+      fill_in 'user[email]', with: 'admin@greencommons.org'
+      fill_in 'user[password]', with: 'thecommons'
+      click_button 'Log in'
+    end
+
+    expect(page).to have_text('Signed in successfully.')
+  end
+
+  scenario 'users can logout' do
+    create(:user, email: 'admin@greencommons.org', password: 'thecommons')
+    visit new_user_session_path
+
+    within('#new_user') do
+      fill_in 'user[email]', with: 'admin@greencommons.org'
+      fill_in 'user[password]', with: 'thecommons'
+      click_button 'Log in'
+    end
+
+    click_link 'Logout'
+    expect(page).to have_text('Signed out successfully.')
+  end
+end


### PR DESCRIPTION
[Related Issue: #74](https://github.com/greencommons/commons/issues/74) and [#53](https://github.com/greencommons/commons/issues/53).

This is a preliminary PR for issue #74. Since users must be logged in to manage groups, I thought it would be nice to have some happy path acceptance tests for the login/logout. I know Devise is handling it, but it's always nice to ensure that we won't have a regression one day by messing with the login form for example.

Implementing this also led me to wonder if we want to stub the logged in user in the acceptance tests for the groups management (faster), or if we should run the user through the login page every time (slower). I like the latter more, since it acts more like a real user, but I'm worried about the speed cost.

PS: These tests pointed out that `autocomplete: off` was duplicated in the `session/new` view.