### PR TITLE
Move epub-parser out of the development group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,11 +22,11 @@ gem 'uglifier', '>= 1.3.0'
 gem 'react-rails', '~> 1.10'
 gem 'pundit'
 gem 'kiba', '~> 1.0.0'
+gem 'epub-parser'
 
 group :development do
   gem 'bummr'
   gem 'bundler-audit'
-  gem 'epub-parser'
   gem 'guard-livereload', '>= 2.5.2', require: false
   gem 'listen', '~> 3.0.5'
   gem 'spring'


### PR DESCRIPTION
In the last PR, I missed the `epub-parser` gem that's also required to run the ERL process. In this PR, I move this gem out of the `development` group to make it available on Heroku. I did a run in production mode in local and everything seems fine now.