### PR TITLE
Change single pipe operator to double pipe in sidekiq config

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,7 +3,7 @@
 staging:
   :concurrency: 10
 production:
-  :concurrency: <%= ENV['WORKER_CONCURRENCY'] | 15 %>
+  :concurrency: <%= ENV['WORKER_CONCURRENCY'] || 15 %>
 :queues:
   - 'default'
   - ['elasticsearch', 2]


### PR DESCRIPTION
There seems to be a typo in the `sidekiq.yml` file where a single pipe was used instead of the double pipe (OR). In order to have Sidekiq run correctly on Heroku, we need to fix it.