### PR TITLE
Add :environment to the elastic search reset index task

### DIFF
--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,6 +1,6 @@
 namespace :elasticsearch do
   desc 'Deletes the "resource" index and regenerates it with all records currently in Resource'
-  task :reset_resource_index do
+  task reset_resource_index: :environment do
     client = Elasticsearch::Client.new(
       url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log: true
     )


### PR DESCRIPTION
[Related Issue: ElasticSearch Rake task fails #81](https://github.com/greencommons/commons/issues/81)

To avoid random failures of the `reset_resource_index` task, we need to add `:resource` in its definition.