### PR TITLE
Fix the index_name generation for Resource

### DIFF
--- a/app/service/search_index.rb
+++ b/app/service/search_index.rb
@@ -1,6 +1,6 @@
 class SearchIndex
-  def self.index_name(record)
-    "#{record.class.name.pluralize.downcase}-#{Rails.env}"
+  def self.index_name(klass)
+    "#{klass.name.pluralize.downcase}-#{Rails.env}"
   end
 
   def self.log_elasticsearch_warning(message)

--- a/lib/etl/load/create_new_resource_record.rb
+++ b/lib/etl/load/create_new_resource_record.rb
@@ -3,14 +3,14 @@ class CreateNewResourceRecord
     @attributes = attributes
 
     if existing_record
-      ap "Title already in database: #{title}" # rubocop:disable Rails/Output
+      ap "Title already in database: #{title}"
     else
       record = Resource.create!(attributes)
 
-      ap "Title: #{record.title}" # rubocop:disable Rails/Output
-      ap 'Metadata: ' # rubocop:disable Rails/Output
-      ap record.metadata # rubocop:disable Rails/Output
-      ap "Content: #{record.content.truncate(100)}" # rubocop:disable Rails/Output
+      ap "Title: #{record.title}"
+      ap 'Metadata: '
+      ap record.metadata
+      ap "Content: #{record.content.truncate(100)}"
     end
   end
 

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -4,7 +4,11 @@ namespace :elasticsearch do
     client = Elasticsearch::Client.new(
       url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log: true
     )
-    client.indices.delete index: 'resources'
+
+    if client.indices.exists? index: Resource.index_name
+      client.indices.delete index: Resource.index_name
+    end
+
     Resource.__elasticsearch__.create_index!
     Resource.import
   end

--- a/spec/service/search_index_spec.rb
+++ b/spec/service/search_index_spec.rb
@@ -3,9 +3,7 @@ require 'rails_helper'
 RSpec.describe SearchIndex do
   describe '.index_name' do
     it 'returns the correct index name, given the model and environment' do
-      resource = build_stubbed(:resource)
-
-      name = SearchIndex.index_name(resource)
+      name = SearchIndex.index_name(Resource)
 
       expect(name).to eq 'resources-test'
     end


### PR DESCRIPTION
Related Issues: #57, #96, #97 

This Pull Request changes the way the `index_name` is generated. The method now expects a class such as `Resource` to be passed.

I also removed some `rubocop:disable` that were being reported as unecessary - I'm not getting the warnings anymore.

Finally, I updated the `reset_resource_index` to include an existence check before trying to delete the index (in case it was renamed, not created yet, etc.).

Once this is live, I will reset everything in production (Database + ElasticSearch) and try to import resources from S3.