### PR TITLE
Add simple traces in ETL steps

### DIFF
--- a/lib/etl/extract/process_all_files_in_s3_bucket.rb
+++ b/lib/etl/extract/process_all_files_in_s3_bucket.rb
@@ -10,6 +10,8 @@ class ProcessAllFilesInS3Bucket
   def each
     epub_files.each do |epub_key|
       Tempfile.open(['island_press', '.epub'], dir, binmode: true) do |tempfile|
+        ap "Processing #{epub_key}..."
+
         s3.get_object(
           response_target: tempfile.path,
           bucket: bucket_name,

--- a/lib/etl/load/create_new_resource_record.rb
+++ b/lib/etl/load/create_new_resource_record.rb
@@ -1,5 +1,6 @@
 class CreateNewResourceRecord
   def write(attributes)
+    ap 'Saving...'
     @attributes = attributes
 
     if existing_record

--- a/lib/etl/transform/transform_epub.rb
+++ b/lib/etl/transform/transform_epub.rb
@@ -2,6 +2,7 @@ require 'epub/parser'
 
 class TransformEpub
   def process(input_epub)
+    ap 'Transforming...'
     @input_epub = input_epub
 
     {


### PR DESCRIPTION
In order to fix #102, we need to know exactly which epub is failing in order to reproduce the bug in local and fix it. This PR includes a few prints in the ETL steps that will tell us which epub is being processed.