### PR TITLE
Skip epub creation when attributes are not a hash

### DIFF
--- a/lib/etl/load/create_new_resource_record.rb
+++ b/lib/etl/load/create_new_resource_record.rb
@@ -1,11 +1,17 @@
 class CreateNewResourceRecord
   def write(attributes)
-    ap 'Saving...'
     @attributes = attributes
+
+    unless @attributes.is_a? Hash
+      ap 'Error: given attributes were not provided as a hash:'
+      ap @attributes
+      return
+    end
 
     if existing_record
       ap "Title already in database: #{title}"
     else
+      ap 'Saving...'
       record = Resource.create!(attributes)
 
       ap "Title: #{record.title}"


### PR DESCRIPTION
Related to #102. 

This pull request adds a simple return statement if the `CreateNewResourceRecord` class receives anything but a hash in the `attributes` parameter.