### PR TITLE
Setup ES indices for Groups and Lists

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,8 @@ Rails/HasAndBelongsToMany:
   Enabled: false
 
 # RSpec Styles
+RSpec/DescribeClass:
+  Enabled: false
 RSpec/DescribedClass:
   Enabled: false
 RSpec/FilePath:

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -1,0 +1,16 @@
+module Indexable
+  extend ActiveSupport::Concern
+
+  included do
+    include Elasticsearch::Model
+    index_name SearchIndex.index_name(self)
+
+    after_commit on: [:create, :update] do
+      AddToIndexJob.perform_async(self.class.name, id)
+    end
+
+    after_commit on: [:destroy] do
+      RemoveFromIndexJob.perform_async(self.class.name, id)
+    end
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,4 +1,6 @@
 class Group < ApplicationRecord
+  include Indexable
+
   has_paper_trail
   acts_as_taggable
 

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,4 +1,6 @@
 class List < ApplicationRecord
+  include Indexable
+
   has_paper_trail
   acts_as_taggable
 

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,6 +1,5 @@
 class Resource < ApplicationRecord
-  include Elasticsearch::Model
-  index_name SearchIndex.index_name(self)
+  include Indexable
 
   RESOURCE_TYPES = {
     article: 0,
@@ -22,12 +21,4 @@ class Resource < ApplicationRecord
   validates :title, :resource_type, presence: true
 
   scope :sort_by_created_at, -> { order('created_at DESC') }
-
-  after_commit on: [:create, :update] do
-    AddToIndexJob.perform_async(self.class.name, id)
-  end
-
-  after_commit on: [:destroy] do
-    RemoveFromIndexJob.perform_async(self.class.name, id)
-  end
 end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,15 +1,42 @@
 namespace :elasticsearch do
-  desc 'Deletes the "resource" index and regenerates it with all records currently in Resource'
-  task reset_resource_index: :environment do
+
+  def reset_index(klass)
     client = Elasticsearch::Client.new(
       url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log: true
     )
 
-    if client.indices.exists? index: Resource.index_name
-      client.indices.delete index: Resource.index_name
+    if client.indices.exists? index: klass.index_name
+      client.indices.delete index: klass.index_name
     end
 
-    Resource.__elasticsearch__.create_index!
-    Resource.import
+    klass.__elasticsearch__.create_index!
+
+    begin
+      klass.import
+    rescue Faraday::ConnectionFailed => e
+      ap e
+      ap 'Indexing records one at a time...'
+      klass.all.each { |r| r.__elasticsearch__.index_document }
+    end
+  end
+
+  desc 'Deletes the "resource", "group" and "list" indices and regenerates it with all records'
+  task reset_all_indices: :environment do
+    [Resource, Group, List].each { |klass| reset_index(klass) }
+  end
+
+  desc 'Deletes the "resource" index and regenerates it with all records currently in Resource'
+  task reset_resource_index: :environment do
+    reset_index(Resource)
+  end
+
+  desc 'Deletes the "group" index and regenerates it with all records currently in Group'
+  task reset_group_index: :environment do
+    reset_index(Group)
+  end
+
+  desc 'Deletes the "list" index and regenerates it with all records currently in List'
+  task reset_list_index: :environment do
+    reset_index(List)
   end
 end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,5 +1,4 @@
 namespace :elasticsearch do
-
   def reset_index(klass)
     client = Elasticsearch::Client.new(
       url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log: true

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -84,4 +84,6 @@ RSpec.describe Group do
     it { is_expected.to have_many(:users) }
     it { is_expected.to have_many(:lists) }
   end
+
+  it_behaves_like 'indexable', :group
 end

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -18,30 +18,5 @@ RSpec.describe List do
     it { is_expected.to have_and_belong_to_many(:resources) }
   end
 
-  describe 'Callbacks' do
-    describe 'after_save' do
-      it 'adds the list to the search index after creation' do
-        allow(AddToIndexJob).to receive(:perform_async)
-
-        list = create(:list)
-
-        expect(AddToIndexJob).to have_received(:perform_async).
-          with(list.class.name, list.id)
-      end
-    end
-
-    describe 'after_destroy' do
-      it 'removes the list from the search index after deletion' do
-        list = create(:list)
-        allow(RemoveFromIndexJob).to receive(:perform_async)
-
-        list.destroy
-
-        expect(RemoveFromIndexJob).to have_received(:perform_async).
-          with(list.class.name, list.id)
-      end
-    end
-  end
-
   it_behaves_like 'indexable', :list
 end

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -17,28 +17,5 @@ RSpec.describe Resource do
     it { is_expected.to have_and_belong_to_many(:lists) }
   end
 
-  describe 'Callbacks' do
-    describe 'after_save' do
-      it 'adds the resource to the search index after creation' do
-        allow(AddToIndexJob).to receive(:perform_async)
-
-        resource = create(:resource)
-
-        expect(AddToIndexJob).to have_received(:perform_async).
-          with(resource.class.name, resource.id)
-      end
-    end
-
-    describe 'after_destroy' do
-      it 'removes the resource from the search index after deletion' do
-        resource = create(:resource)
-        allow(RemoveFromIndexJob).to receive(:perform_async)
-
-        resource.destroy
-
-        expect(RemoveFromIndexJob).to have_received(:perform_async).
-          with(resource.class.name, resource.id)
-      end
-    end
-  end
+  it_behaves_like 'indexable', :resource
 end

--- a/spec/support/shared/indexable.rb
+++ b/spec/support/shared/indexable.rb
@@ -1,0 +1,26 @@
+RSpec.shared_examples 'indexable' do |name|
+  describe 'Callbacks' do
+    describe 'after_save' do
+      it "adds the #{name} to the search index after creation" do
+        allow(AddToIndexJob).to receive(:perform_async)
+
+        record = create(name)
+
+        expect(AddToIndexJob).to have_received(:perform_async).
+          with(record.class.name, record.id)
+      end
+    end
+
+    describe 'after_destroy' do
+      it "removes the #{name} from the search index after deletion" do
+        record = create(name)
+        allow(RemoveFromIndexJob).to receive(:perform_async)
+
+        record.destroy
+
+        expect(RemoveFromIndexJob).to have_received(:perform_async).
+          with(record.class.name, record.id)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Related issue: #98 

> Taking the search term entered and searching across Group, Resource, and List to begin with. The search page should return a list of all items combined together.

This pull request turns `Group` and `List` into models indexed with ElasticSearch. The logic was extracted from the `Resource` model and moved into a concern (`Indexable`) for easy reuse. 

New rake tasks were also added to reset/create the indices for the new models (with a fallback if the `Model.import` method fails). 

Finally, the tests checking if a model is correctly indexed on `create` / `delete` were moved into a shared example and included in each of the models mentioned above.