### PR TITLE
Move FactoryGirl out of test/development environments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'pundit'
 gem 'kiba', '~> 1.0.0'
 gem 'epub-parser'
 gem 'awesome_print'
+gem 'factory_girl_rails'
 
 group :development do
   gem 'bummr'
@@ -39,7 +40,6 @@ group :development, :test do
   gem 'climate_control'
   gem 'database_cleaner'
   gem 'dotenv-rails'
-  gem 'factory_girl_rails'
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.5'
   gem 'rspec-wait'


### PR DESCRIPTION
Related to #87.

To generate some sample data, I'd like to reuse the code created in the `seeds.rb` file (just copy/paste in the console) and to do this, we need Factory Girl available in production. Also, this will help if we ever need to run the seeds in an environment other than development (staging for example).