### PR TITLE
Add support for ETL of JSON resource and group data.

### DIFF
--- a/ETL.md
+++ b/ETL.md
@@ -35,12 +35,20 @@ For more information, see the [`kiba`] `README.md` file.
 
 ## Usage
 
-Then run the rake task to import the records,
+Then run the rake tasks to import the records,
 transform them,
 and load them into the database:
 
 ```
-bundle exec rake etl:import_local_epub
+with local test files:
+
+bundle exec rake etl:import_local_json_resources
+bundle exec rake etl:import_local_json_groups
+
+or with files from S3:
+
+bundle exec rake etl:import_s3_json_resources
+bundle exec rake etl:import_s3_json_groups
 ```
 
 ## Development
@@ -51,16 +59,24 @@ kiba ETL source files are in `lib/etl/`
 
 ```
 ├── common.rb
-├── convert-islandpress.etl
+├── process_local_json_resources.etl
+├── process_local_json_groups.etl
+├── process_s3_json_resources.etl
+├── process_s3_json_groups.etl
 ├── data
-│   ├── sample_island_press_1.epub
-│   └── sample_island_press_2.epub
+│   ├── good_resource_array.json
+│   └── good_group_array.json
 ├── extract
-│   └── process_all_files_in_local_folder.rb
+│   └── process_files_in_s3_bucket_folders.rb
 ├── load
-│   └── create_new_resource_record.rb
-└── transform
-    └── transform_epub.rb
+│   ├── create_new_resource_records.rb
+│   └── create_new_group_records.rb
+├── transform
+│   └── transform_json.rb
+└── schema
+    ├── resource_array_schema.json
+    └── group_array_schema.json
+    
 ```
 
 ### Rake Tasks

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'kiba', '~> 1.0.0'
 gem 'epub-parser'
 gem 'awesome_print'
 gem 'factory_girl_rails'
+gem 'json-schema'
 
 group :development do
   gem 'bummr'

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ gem 'pundit'
 gem 'kiba', '~> 1.0.0'
 gem 'epub-parser'
 gem 'awesome_print'
+gem 'factory_girl_rails'
 
 group :development do
   gem 'bummr'
@@ -39,7 +40,6 @@ group :development, :test do
   gem 'climate_control'
   gem 'database_cleaner'
   gem 'dotenv-rails'
-  gem 'factory_girl_rails'
   gem 'pry-byebug'
   gem 'rspec-rails', '~> 3.5'
   gem 'rspec-wait'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.0.2)
+    json-schema (2.7.0)
+      addressable (>= 2.4)
     kiba (1.0.0)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -368,6 +370,7 @@ DEPENDENCIES
   guard-livereload (>= 2.5.2)
   high_voltage (~> 3.0.0)
   jquery-rails
+  json-schema
   kiba (~> 1.0.0)
   listen (~> 3.0.5)
   paper_trail
@@ -392,7 +395,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 2.3.2p217
+   ruby 2.3.3p222
 
 BUNDLED WITH
    1.13.6

--- a/lib/etl/common.rb
+++ b/lib/etl/common.rb
@@ -1,9 +1,13 @@
 # Source files (lib/etl/extract)
 require_relative 'extract/process_all_files_in_local_folder'
 require_relative 'extract/process_all_files_in_s3_bucket'
+require_relative 'extract/process_files_in_s3_bucket_folders'
 
 # Transform files (lib/etl/transform)
 require_relative 'transform/transform_epub'
+require_relative 'transform/transform_json'
 
 # Destination files (lib/etl/load)
 require_relative 'load/create_new_resource_record'
+require_relative 'load/create_new_resource_records'
+require_relative 'load/create_new_group_records'

--- a/lib/etl/data/bad_group_array.json
+++ b/lib/etl/data/bad_group_array.json
@@ -1,0 +1,17 @@
+[
+	{
+		"namEE": "Ima Invalid Group",
+		"long_description": "Org for goodness sake",
+		"url": "http://www.goodnesssake.org",
+		"metadata": {
+		}
+	},
+	{
+		"name": "Ima Good One",
+		"long_description": "All day, every day, combating polluting corporations.",
+		"email": "support@greenfighingtback.org",
+		"metadata": {
+			"founded": "2017-01-01"
+		}
+	}
+]

--- a/lib/etl/data/bad_resource_array.json
+++ b/lib/etl/data/bad_resource_array.json
@@ -1,0 +1,11 @@
+[
+	{
+		"TheTitle": "Bad Medicine",
+		"content": "Take one and count to ten",
+		"metadata": {
+			"creators": "J Ellison",
+			"date": "2002-9-05",
+			"publisher": "Aukland Muse"
+		}
+	}
+]

--- a/lib/etl/data/good_group_array.json
+++ b/lib/etl/data/good_group_array.json
@@ -1,0 +1,22 @@
+[
+	{
+		"name": "A Green Group",
+		"long_description": "Founded in 1991, this organization aims to combat climate change and otherwise save humanity.",
+		"url": "http://www.agreengroup.org",
+		"metadata": {
+		}
+	},
+	{
+		"name": "Climate Uncles",
+		"long_description": "Uncles of the future generation, we stand together and protect.",
+		"email": "info@climateuncles.org",
+		"metadata": {
+			"founded": "2016-01-05"
+		}
+	},
+	{
+		"name": "Clean Energies R Us",
+		"email": "cleaner@cleanenergiesrus.org",
+		"short_description": "Uncles of the future generation, we stand together and protect."
+	}
+]

--- a/lib/etl/data/good_resource_array.json
+++ b/lib/etl/data/good_resource_array.json
@@ -1,0 +1,21 @@
+[
+	{
+		"title": "Absurdity Realized",
+		"content": "This is the beginning and the end.",
+		"metadata": {
+			"creators": "N. Chomsky",
+			"date": "2006-10-01",
+			"publisher": "MIT Press"
+		}
+	},
+	{
+		"title": "Never Again",
+		"content": "Eat it while it's hot.",
+		"metadata": {
+			"creators": "Christopher Hitchens",
+			"date": "1987-03-05",
+			"publisher": "Oxford Press",
+			"schema": "blahding/1.2.3"
+		}
+	}
+]

--- a/lib/etl/extract/process_files_in_s3_bucket_folders.rb
+++ b/lib/etl/extract/process_files_in_s3_bucket_folders.rb
@@ -1,0 +1,52 @@
+require 'aws-sdk'
+require 'tempfile'
+
+class ProcessFilesInS3BucketFolders
+  def initialize(bucket_name, prefix_folders, file_ext)
+    @bucket_name = bucket_name
+    @prefix_folders = prefix_folders
+    @file_ext = file_ext
+  end
+
+  def each
+    filtered_files.each do |file_key|
+      Tempfile.open('s3data', dir, binmode: true) do |tempfile|
+        s3.get_object(
+          response_target: tempfile.path,
+          bucket: bucket_name,
+          key: file_key,
+        )
+
+        yield(tempfile, file_key)
+      end
+    end
+  end
+
+  private
+
+  attr_reader :bucket_name, :prefix_folders, :file_ext
+
+  def dir
+    "#{Rails.root}/tmp"
+  end
+
+  def filtered_files
+    file_keys.grep(/#{file_ext}/)
+  end
+
+  def file_keys
+    arr = []
+    @prefix_folders.each do |prefix_folder|
+      arr += s3.list_objects(bucket_location(prefix_folder)).contents.map(&:key)
+    end
+    arr
+  end
+
+  def s3
+    @_s3 = Aws::S3::Client.new
+  end
+
+  def bucket_location(prefix_folder)
+    { bucket: bucket_name, prefix: prefix_folder }
+  end
+end

--- a/lib/etl/load/create_new_group_records.rb
+++ b/lib/etl/load/create_new_group_records.rb
@@ -1,0 +1,32 @@
+class CreateNewGroupRecords
+  def write(attributes_list)
+    @attributes_list = attributes_list
+
+    attributes_list.each do |attributes|
+      puts "#{attributes["name"]}"
+      
+      if existing_record attributes
+        ap "Name already in database: #{name attributes}" # rubocop:disable Rails/Output
+      else
+        record = Group.create!(attributes)
+
+        ap "Name: #{record.name}" # rubocop:disable Rails/Output
+        ap 'Metadata: ' # rubocop:disable Rails/Output
+        ap record.metadata # rubocop:disable Rails/Output
+        ap record.long_description # rubocop:disable Rails/Output
+      end
+    end
+  end
+
+  private
+
+  attr_reader :attributes_list
+
+  def existing_record(attributes)
+    Group.find_by(name: name(attributes))
+  end
+
+  def name(attributes)
+    attributes.fetch(:name)
+  end
+end

--- a/lib/etl/load/create_new_resource_records.rb
+++ b/lib/etl/load/create_new_resource_records.rb
@@ -1,0 +1,32 @@
+class CreateNewResourceRecords
+  def write(attributes_list)
+    @attributes_list = attributes_list
+
+    attributes_list.each do |attributes|
+      puts "#{attributes["title"]}"
+      
+      if existing_record attributes
+        ap "Title already in database: #{title attributes}" # rubocop:disable Rails/Output
+      else
+        record = Resource.create!(attributes)
+
+        ap "Title: #{record.title}" # rubocop:disable Rails/Output
+        ap 'Metadata: ' # rubocop:disable Rails/Output
+        ap record.metadata # rubocop:disable Rails/Output
+        ap "Content: #{record.content.truncate(100)}" # rubocop:disable Rails/Output
+      end
+    end
+  end
+
+  private
+
+  attr_reader :attributes_list
+
+  def existing_record(attributes)
+    Resource.find_by(title: title(attributes))
+  end
+
+  def title(attributes)
+    attributes.fetch(:title)
+  end
+end

--- a/lib/etl/process_local_json_groups.etl
+++ b/lib/etl/process_local_json_groups.etl
@@ -1,0 +1,5 @@
+require_relative 'common'
+
+source(ProcessAllFilesInLocalFolder, 'lib/etl/data/good*group*.json')
+transform(TransformJsonGroups)
+destination(CreateNewGroupRecords)

--- a/lib/etl/process_local_json_resources.etl
+++ b/lib/etl/process_local_json_resources.etl
@@ -1,0 +1,5 @@
+require_relative 'common'
+
+source(ProcessAllFilesInLocalFolder, 'lib/etl/data/good*resource*.json')
+transform(TransformJsonResources)
+destination(CreateNewResourceRecords)

--- a/lib/etl/process_s3_json_groups.etl
+++ b/lib/etl/process_s3_json_groups.etl
@@ -1,0 +1,5 @@
+require_relative 'common'
+
+source(ProcessFilesInS3BucketFolders, 'knowledge.commons', ['valid_data/groups/'], '.json')
+transform(TransformJsonGroups)
+destination(CreateNewGroupRecords)

--- a/lib/etl/process_s3_json_resources.etl
+++ b/lib/etl/process_s3_json_resources.etl
@@ -1,0 +1,5 @@
+require_relative 'common'
+
+source(ProcessFilesInS3BucketFolders, 'knowledge.commons', ['valid_data/resources/'], '.json')
+transform(TransformJsonResources)
+destination(CreateNewResourceRecords)

--- a/lib/etl/schema/group_array_schema.json
+++ b/lib/etl/schema/group_array_schema.json
@@ -1,0 +1,103 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "self": {
+        "vendor": "org.islandpress",
+        "name": "GroupArraySchema",
+        "format": "jsonschema",
+        "version": "0.0.1"
+    },
+    "definitions": {
+        "schema_version_type": {
+            "type": "string",
+            "title" : "Schema Version",
+            "pattern": "^[a-zA-Z0-9_]+/[0-9]+\\.[0-9]+\\.[0-9]$"
+        },
+        "detailed_datetime_type": {
+            "type": "string",
+            "title": "Detailed Date Time",
+            "description": "Format that schema validator can accept; example: 2015-10-16 13:29:27.282294",
+            "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]+"
+        },
+        "day_datetime_type": {
+            "type": "string",
+            "title": "Day Date Time",
+            "description": "Format that schema validator can accept; example: 2015-10-16",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "year_datetime_type": {
+            "type": "string",
+            "title": "Year Date Time",
+            "description": "Format that schema validator can accept; example: 2015",
+            "pattern": "^[0-9]{4}$"
+        },
+        "generic_datetime_type": {
+            "oneOf" :[
+                { "$ref": "#/definitions/detailed_datetime_type" },
+                { "$ref": "#/definitions/day_datetime_type" },
+                { "$ref": "#/definitions/year_datetime_type" }
+            ],
+            "title": "Generic Date Format"
+        },
+        "email_type": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_\\.-]+@[a-zA-Z0-9_\\.-]+\\.[a-zA-Z]+$"
+        },
+        "url_type": {
+            "type": "string",
+            "pattern": "^(https?://)?([/a-zA-Z0-9_-]+\\.)+"
+        },
+        "metadata_type": {
+            "type": "object",
+            "properties": {
+                "schema": { 
+                    "$ref" : "#/definitions/schema_version_type",
+                    "title": "Schema Version"
+                }
+            },
+            "additionalProperties": true
+        },
+        "record_type": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "title": "Group Name"
+                 },
+                "short_description": {
+                    "type": "string",
+                    "title": "Short Description"
+                 },
+                "long_description": {
+                    "type": "string",
+                    "title": "Long Description"
+                 },
+                "url": {
+                    "$ref": "#/definitions/url_type",
+                    "title": "URL"
+                 },
+                "email": {
+                    "$ref": "#/definitions/email_type",
+                    "title": "Email"
+                 },
+                "metadata": {
+                    "$ref": "#/definitions/metadata_type",
+                    "title": "Metadata"
+                 },
+                "created_at": {
+                    "$ref": "#/definitions/generic_datetime_type",
+                    "title": "Creation Time"
+                 },
+                "updated_at": {
+                    "$ref": "#/definitions/generic_datetime_type",
+                    "title": "Last Update Time"
+                 }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        }
+    },
+    "type": "array",
+    "title": "Group Array Doc",
+    "items": { "$ref": "#/definitions/record_type" },
+    "description": "Green Commons Group Array Document"
+ }

--- a/lib/etl/schema/resource_array_schema.json
+++ b/lib/etl/schema/resource_array_schema.json
@@ -1,0 +1,119 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "self": {
+        "vendor": "org.islandpress",
+        "name": "ResourceArraySchema",
+        "format": "jsonschema",
+        "version": "0.0.1"
+    },
+    "definitions": {
+        "schema_version_type": {
+            "type": "string",
+            "title" : "Schema Version",
+            "pattern": "^[a-zA-Z0-9_]+/[0-9]+\\.[0-9]+\\.[0-9]$"
+        },
+        "detailed_datetime_type": {
+            "type": "string",
+            "title": "Detailed Date Time",
+            "description": "Format that schema validator can accept; example: 2015-10-16 13:29:27.282294",
+            "pattern": "[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]+"
+        },
+        "day_datetime_type": {
+            "type": "string",
+            "title": "Day Date Time",
+            "description": "Format that schema validator can accept; example: 2015-10-16",
+            "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+        },
+        "year_datetime_type": {
+            "type": "string",
+            "title": "Year Date Time",
+            "description": "Format that schema validator can accept; example: 2015",
+            "pattern": "^[0-9]{4}$"
+        },
+        "generic_datetime_type": {
+            "oneOf" :[
+                { "$ref": "#/definitions/detailed_datetime_type" },
+                { "$ref": "#/definitions/day_datetime_type" },
+                { "$ref": "#/definitions/year_datetime_type" }
+            ],
+            "title": "Generic Date Format"
+        },
+        "url_type": {
+            "type": "string",
+            "pattern": "^(https?://)?([/a-zA-Z0-9_-]+\\.)+"
+        },
+        "s3_inclusive_url_type": {
+            "type": "string",
+            "pattern": "^((https?://)|(s3://))?([/a-zA-Z0-9_-]+\\.)+"
+        },
+        "metadata_type": {
+            "type": "object",
+            "properties": {
+                "creators": {
+                    "type": "string",
+                    "title": "Author Names"
+                 },
+                "date": {
+                    "$ref": "#/definitions/generic_datetime_type",
+                    "title": "Published Date"
+                 },
+                "publisher": {
+                    "type": "string",
+                    "title": "Publisher"
+                },
+                "content_download_link": {
+                    "$ref": "#/definitions/s3_inclusive_url_type",
+                    "title": "Content Download Link"
+                },
+                "content_record_link": {
+                    "$ref": "#/definitions/url_type",
+                    "title": "Content Record Link"
+                },
+                "schema": { 
+                    "$ref" : "#/definitions/schema_version_type",
+                    "title": "Schema Version"
+                }
+            },
+            "additionalProperties": true
+        },
+        "record_type": {
+            "type": "object",
+            "properties": {
+                "resource_type": {
+                    "enum": [ "article", "book", "report" ],
+                    "title": "Resource Type"
+                },
+                "user_id": {
+                    "type": "string",
+                    "title": "User id"
+                 },
+                "created_at": {
+                    "$ref": "#/definitions/generic_datetime_type",
+                    "title": "Creation Time"
+                 },
+                "updated_at": {
+                    "$ref": "#/definitions/generic_datetime_type",
+                    "title": "Last Update Time"
+                 },
+                "title": {
+                    "type": "string",
+                    "title": "Title"
+                 },
+                "content": {
+                    "type": "string",
+                    "title": "Content"
+                 },
+                "metadata": {
+                    "$ref": "#/definitions/metadata_type",
+                    "title": "Metadata"
+                 }
+            },
+            "required": ["title", "content", "metadata"],
+            "additionalProperties": false
+        }
+    },
+    "type": "array",
+    "title": "Resource Array Doc",
+    "items": { "$ref": "#/definitions/record_type" },
+    "description": "Green Commons Resource Array Document"
+ }

--- a/lib/etl/transform/transform_json.rb
+++ b/lib/etl/transform/transform_json.rb
@@ -1,0 +1,38 @@
+require 'json'
+require 'json-schema'
+
+class TransformJson
+  def process(input_json)
+    @input_json = input_json
+    pl = parsed_list
+    JSON::Validator.validate(schema_fname, pl)
+    pl
+    
+  rescue => error
+    ap "Error opening json file: #{error}"
+  end
+
+  private
+
+  attr_reader :input_json, :schema_fname
+  
+  def schema_fname
+    raise NotImplementedError.new("#{self.class.name}#area is an abstract method.")
+  end
+  
+  def parsed_list
+    JSON.parse(File.read(input_json), :symbolize_names => true)
+  end
+end
+
+class TransformJsonResources < TransformJson
+  def schema_fname
+    "lib/etl/schema/resource_array_schema.json"
+  end
+end
+
+class TransformJsonGroups < TransformJson
+  def schema_fname
+    "lib/etl/schema/group_array_schema.json"
+  end
+end

--- a/lib/tasks/import_json.rake
+++ b/lib/tasks/import_json.rake
@@ -1,0 +1,38 @@
+namespace :etl do
+  desc 'ETL task to import local .json resource array files'
+
+  task import_local_json_resources: :environment do
+    etl_filename = 'lib/etl/process_local_json_resources.etl'
+    script_content = IO.read(etl_filename)
+    job_definition = Kiba.parse(script_content, etl_filename)
+    Kiba.run(job_definition)
+  end
+
+  desc 'ETL task to import local .json group array files'
+
+  task import_local_json_groups: :environment do
+    etl_filename = 'lib/etl/process_local_json_groups.etl'
+    script_content = IO.read(etl_filename)
+    job_definition = Kiba.parse(script_content, etl_filename)
+    Kiba.run(job_definition)
+  end
+
+  desc 'ETL task to import .json resource array files from our S3 bucket'
+
+  task import_s3_json_resources: :environment do
+    etl_filename = 'lib/etl/process_s3_json_resources.etl'
+    script_content = IO.read(etl_filename)
+    job_definition = Kiba.parse(script_content, etl_filename)
+    Kiba.run(job_definition)
+  end
+
+  desc 'ETL task to import .json group array files from our S3 bucket'
+
+  task import_s3_json_groups: :environment do
+    etl_filename = 'lib/etl/process_s3_json_groups.etl'
+    script_content = IO.read(etl_filename)
+    job_definition = Kiba.parse(script_content, etl_filename)
+    Kiba.run(job_definition)
+  end
+
+end


### PR DESCRIPTION
* ETL.md shows rakes to use and new ETL files.
* Groups and Resources JSON schema are compatible with and extend db/schema.rb defs.
* Local data in lib/etl/data are useful for simple tests.
* Ingestion of JSON from S3 is supported.
* S3 JSON data derives from sources including EPUBs augmented with ONIX data.