### PR TITLE
Implement ES update mechanism

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,8 @@ Rails/HasAndBelongsToMany:
   Enabled: false
 
 # RSpec Styles
+RSpec/AnyInstance:
+  Enabled: false
 RSpec/DescribeClass:
   Enabled: false
 RSpec/DescribedClass:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -395,7 +395,7 @@ DEPENDENCIES
   web-console
 
 RUBY VERSION
-   ruby 2.3.3p222
+   ruby 2.3.2p217
 
 BUNDLED WITH
    1.13.6

--- a/app/jobs/update_index_job.rb
+++ b/app/jobs/update_index_job.rb
@@ -1,0 +1,14 @@
+class UpdateIndexJob
+  include Sidekiq::Worker
+  sidekiq_options queue: 'elasticsearch', retry: true
+
+  def perform(model_name, id, changed)
+    Rails.logger.tagged('ELASTICSEARCH') do
+      Rails.logger.warn(
+        "Hey! Updating the #{model_name} index for record id# #{id}"
+      )
+    end
+
+    SearchIndex.new(model_name: model_name, id: id, changed: changed).update
+  end
+end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -5,11 +5,15 @@ module Indexable
     include Elasticsearch::Model
     index_name SearchIndex.index_name(self)
 
-    after_commit on: [:create, :update] do
+    after_create do
       AddToIndexJob.perform_async(self.class.name, id)
     end
 
-    after_commit on: [:destroy] do
+    after_update do
+      UpdateIndexJob.perform_async(self.class.name, id, changed)
+    end
+
+    after_destroy do
       RemoveFromIndexJob.perform_async(self.class.name, id)
     end
   end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -5,15 +5,15 @@ module Indexable
     include Elasticsearch::Model
     index_name SearchIndex.index_name(self)
 
-    after_create do
+    after_commit on: [:create] do
       AddToIndexJob.perform_async(self.class.name, id)
     end
 
-    after_update do
-      UpdateIndexJob.perform_async(self.class.name, id, changed)
+    after_commit on: [:update] do
+      UpdateIndexJob.perform_async(self.class.name, id, previous_changes.keys)
     end
 
-    after_destroy do
+    after_commit on: [:destroy] do
       RemoveFromIndexJob.perform_async(self.class.name, id)
     end
   end

--- a/app/service/search_index.rb
+++ b/app/service/search_index.rb
@@ -20,8 +20,6 @@ class SearchIndex
   end
 
   def update
-    return add unless changed.any?
-
     perform do
       data = elasticsearch_hash.merge(body: { doc: changes })
       Elasticsearch::Model.client.update(data)

--- a/app/service/search_index.rb
+++ b/app/service/search_index.rb
@@ -9,35 +9,57 @@ class SearchIndex
     end
   end
 
-  def initialize(model_name:, id:)
+  def initialize(model_name:, id:, changed: nil)
     @model_name = model_name
     @id = id
+    @changed = changed
   end
 
   def add
-    if search_index_callbacks_enabled?
-      record = model_name.constantize.find(id)
-      record.__elasticsearch__.index_document
-    else
-      log_callback_warning
+    perform { record.__elasticsearch__.index_document }
+  end
+
+  def update
+    return add unless changed.any?
+
+    perform do
+      data = elasticsearch_hash.merge(body: { doc: changes })
+      Elasticsearch::Model.client.update(data)
     end
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    add
   end
 
   def remove
-    if search_index_callbacks_enabled?
-      Elasticsearch::Model.client.delete(
-        index: model_name.constantize.index_name,
-        type: model_name.downcase,
-        id: id,
-      )
-    else
-      log_callback_warning
-    end
+    perform { Elasticsearch::Model.client.delete(elasticsearch_hash) }
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
   end
 
   private
 
-  attr_reader :id, :model_name
+  attr_reader :id, :model_name, :changed
+
+  def record
+    @_record ||= model_name.constantize.find_by(id: id)
+  end
+
+  def changes
+    record.__elasticsearch__.as_indexed_json.select do |k, _|
+      changed.include?(k.to_s)
+    end
+  end
+
+  def elasticsearch_hash
+    {
+      index: model_name.constantize.index_name,
+      type:  model_name.downcase,
+      id:    id
+    }
+  end
+
+  def perform
+    search_index_callbacks_enabled? ? yield : log_callback_warning
+  end
 
   def search_index_callbacks_enabled?
     ENV.fetch('ENABLE_SEARCH_INDEX_CALLBACKS', true) != 'false'

--- a/app/views/search/new.html.slim
+++ b/app/views/search/new.html.slim
@@ -11,7 +11,7 @@
 
 
 - unless @results.empty?
-  - @results.each do |result|
+  - @results.records.each_with_hit do |result, hit|
     .row
       .well.col-sm-12
         h3.text-center
@@ -24,12 +24,12 @@
           dt
             strong Creator
           dd
-            = result.metadata.fetch(:creators, 'No Author Found')
+            = result.metadata.fetch('creators', 'No Author Found')
           dt
             strong Date Published
           dd
-            = result.metadata.fetch(:date, 'Year Published Unknown')
+            = result.metadata.fetch('date', 'Year Published Unknown')
           dt
             strong Publisher
           dd
-            = result.metadata.fetch(:publisher, 'Publisher Unknown')
+            = result.metadata.fetch('publisher', 'Publisher Unknown')

--- a/app/views/search/new.html.slim
+++ b/app/views/search/new.html.slim
@@ -11,7 +11,7 @@
 
 
 - unless @results.empty?
-  - @results.records.each_with_hit do |result, hit|
+  - @results.each do |result|
     .row
       .well.col-sm-12
         h3.text-center
@@ -24,12 +24,12 @@
           dt
             strong Creator
           dd
-            = result.metadata.fetch('creators', 'No Author Found')
+            = result.metadata.fetch(:creators, 'No Author Found')
           dt
             strong Date Published
           dd
-            = result.metadata.fetch('date', 'Year Published Unknown')
+            = result.metadata.fetch(:date, 'Year Published Unknown')
           dt
             strong Publisher
           dd
-            = result.metadata.fetch('publisher', 'Publisher Unknown')
+            = result.metadata.fetch(:publisher, 'Publisher Unknown')

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -20,8 +20,8 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
     end
 
     scenario 'users should see updated search results' do
-      title = 'Pinterest'
-      new_title = 'Facebook'
+      title = Faker::Book.title
+      new_title = Faker::Book.title
       metadata = { creators: 'Rachel Carson', date: Time.zone.today }
 
       resource = create(:resource, title: title, metadata: metadata)
@@ -49,8 +49,8 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
     end
 
     scenario "users should see updated search results even if the record wasn't indexed" do
-      title = 'Pinterest'
-      new_title = 'Facebook'
+      title = Faker::Book.title
+      new_title = Faker::Book.title
       metadata = { creators: 'Rachel Carson', date: Time.zone.today }
 
       resource = create(:resource, title: title, metadata: metadata)

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -19,6 +19,60 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
       expect(page).to have_text(metadata[:date])
     end
 
+    scenario 'users should see updated search results' do
+      title = 'Pinterest diy vegan mumblecore'
+      new_title = 'Bitters authentic locavore xoxo truffaut'
+      metadata = { creators: 'Rachel Carson', date: Time.zone.today }
+
+      resource = create(:resource, title: title, metadata: metadata)
+
+      wait_for { Resource.search(title).results.total }.to eq(1)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: title
+        click_button 'Search'
+      end
+      expect(page).to have_text(title)
+
+      resource.title = new_title
+      resource.save!
+      wait_for { Resource.search(new_title).results.total }.to eq(1)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: new_title
+        click_button 'Search'
+      end
+
+      expect(page).to have_text(new_title)
+    end
+
+    scenario "users should see updated search results even if the record wasn't indexed" do
+      title = 'Pinterest diy vegan mumblecore'
+      new_title = 'Bitters authentic locavore xoxo truffaut'
+      metadata = { creators: 'Rachel Carson', date: Time.zone.today }
+
+      resource = create(:resource, title: title, metadata: metadata)
+
+      wait_for { Resource.search(title).results.total }.to eq(1)
+      RemoveFromIndexJob.new.perform('Resource', resource.id)
+
+      resource.title = new_title
+      resource.save!
+      wait_for { Resource.search(new_title).results.total }.to eq(1)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: new_title
+        click_button 'Search'
+      end
+
+      expect(page).to have_text(new_title)
+      expect(page).to have_text(metadata[:creators])
+      expect(page).to have_text(metadata[:date])
+    end
+
     scenario 'users should not see search results for deleted files' do
       title = Faker::Hipster.sentence
       metadata = { creators: 'Rachel Carson', date: Time.zone.today }

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -20,8 +20,8 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
     end
 
     scenario 'users should see updated search results' do
-      title = 'Pinterest diy vegan mumblecore'
-      new_title = 'Bitters authentic locavore xoxo truffaut'
+      title = 'Pinterest'
+      new_title = 'Facebook'
       metadata = { creators: 'Rachel Carson', date: Time.zone.today }
 
       resource = create(:resource, title: title, metadata: metadata)
@@ -49,8 +49,8 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
     end
 
     scenario "users should see updated search results even if the record wasn't indexed" do
-      title = 'Pinterest diy vegan mumblecore'
-      new_title = 'Bitters authentic locavore xoxo truffaut'
+      title = 'Pinterest'
+      new_title = 'Facebook'
       metadata = { creators: 'Rachel Carson', date: Time.zone.today }
 
       resource = create(:resource, title: title, metadata: metadata)


### PR DESCRIPTION
Related Issues: #108, #43 and #44 

This pull request adds a new indexing process for existing records. Instead of re-indexing entire documents every time an update is made, it will select the changed fields and send them Elastic Search. In case the record wasn't indexed for some reason, it will perform a full indexing.

I also made the remove process more robust by failing silently if the record wasn't indexed (using the same mechanism as the update: by rescuing from `Elasticsearch::Transport::Transport::Errors::NotFound`. 
