### PR TITLE
Implement basic search page

### DIFF
--- a/app/assets/javascripts/components/autocomplete_form.js.jsx
+++ b/app/assets/javascripts/components/autocomplete_form.js.jsx
@@ -39,7 +39,7 @@ var AutocompleteForm = React.createClass({
   render: function() {
     return (
       <div className="row autocomplete-form">
-        <form id='add-member-form' className="form-horizontal" action={this.props.action} acceptCharset="UTF-8" method="post">
+        <form id='top-page-form' className="form-horizontal" action={this.props.action} acceptCharset="UTF-8" method="post">
           <input name="utf8" type="hidden" value="✓" />
           <input type="hidden" name="authenticity_token" value={this.props.authenticity_token} />
           <div className="col-xs-12 col-md-10">

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,6 +12,6 @@
 @import "components/comment-form";
 @import "components/resource-actions";
 @import "components/btn-count";
+@import "components/top-page-form";
 
 @import "pages/default";
-@import "pages/members";

--- a/app/assets/stylesheets/components/_top-page-form.scss
+++ b/app/assets/stylesheets/components/_top-page-form.scss
@@ -1,3 +1,3 @@
-.add-member-form {
+.top-page-form {
   margin-top: 36px;
 }

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,6 +1,14 @@
 class SearchController < ApplicationController
   def new
+  end
+
+  def show
     skip_authorization
-    @results = params[:query].present? ? Resource.search(params[:query]) : []
+
+    @results = if params[:query].present?
+      Elasticsearch::Model.search(params[:query], [Resource, Group, List])
+    else
+      []
+    end
   end
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -6,9 +6,9 @@ class SearchController < ApplicationController
     skip_authorization
 
     @results = if params[:query].present?
-      Elasticsearch::Model.search(params[:query], [Resource, Group, List])
-    else
-      []
-    end
+                 Elasticsearch::Model.search(params[:query], [Resource, Group, List])
+               else
+                 []
+               end
   end
 end

--- a/app/helpers/summary_cards_helper.rb
+++ b/app/helpers/summary_cards_helper.rb
@@ -1,10 +1,10 @@
 module SummaryCardsHelper
   def summary_card_for(resource)
     {
-      Group => 'shared/summary_cards/group',
-      GroupsUser => 'shared/summary_cards/member',
-      List => 'shared/summary_cards/list',
-      Resource => 'shared/summary_cards/resource',
-    }[resource.class]
+      'Group' => 'shared/summary_cards/group',
+      'GroupsUser' => 'shared/summary_cards/member',
+      'List' => 'shared/summary_cards/list',
+      'Resource' => 'shared/summary_cards/resource',
+    }[resource.class.to_s]
   end
 end

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -7,7 +7,7 @@
     h4 #{@members.count} members
   .col-xs-12.col-md-6.col-lg-6
     - if @admin
-      .add-member-form
+      .top-page-form
         = react_component('AutocompleteForm', { name: 'user-autocomplete',
                                                 field: 'email',
                                                 action: group_members_path,

--- a/app/views/search/new.html.slim
+++ b/app/views/search/new.html.slim
@@ -1,6 +1,6 @@
 .row
   .col-sm-12.col-md-10.col-md-1.col-lg-8.col-lg-offset-2.text-center
-    = form_for new_search_path, method: :get, html: { class: 'form-horizontal customer-search-form' } do |form|
+    = form_tag search_path, method: :get, class: 'form-horizontal customer-search-form' do
       .form-group
         .col-xs-8
           = text_field_tag :query, params[:query], placeholder: 'Enter Search Term', class: 'form-control input-lg'
@@ -8,28 +8,3 @@
             em Try searching for "wind," "green," or "river."
         .col-xs-4
           = submit_tag 'Search', name: nil, class: 'col-lg-12 btn btn-lg btn-primary'
-
-
-- unless @results.empty?
-  - @results.each do |result|
-    .row
-      .well.col-sm-12
-        h3.text-center
-          = result.title
-        .dl-horizontal
-          dt
-            strong Record ID
-          dd
-            = result.id
-          dt
-            strong Creator
-          dd
-            = result.metadata.fetch(:creators, 'No Author Found')
-          dt
-            strong Date Published
-          dd
-            = result.metadata.fetch(:date, 'Year Published Unknown')
-          dt
-            strong Publisher
-          dd
-            = result.metadata.fetch(:publisher, 'Publisher Unknown')

--- a/app/views/search/show.html.slim
+++ b/app/views/search/show.html.slim
@@ -1,0 +1,35 @@
+.row.group-details__row
+  .col-sm-12.col-md-5.col-lg-6
+    h1 Search Results
+  .col-sm-12.col-md-7.col-lg-6.text-center.top-page-form
+    .row
+      .col-xs-12
+        = form_for search_path, method: :get, html: { class: 'form-horizontal customer-search-form' } do |form|
+          .form-group
+            .col-xs-8.col-sm-8.col-sm-offset-2
+              = text_field_tag :query, params[:query], placeholder: 'Enter Search Term', class: 'form-control input-lg'
+            .col-xs-4.col-sm-2
+              = button_tag type: 'submit', class: 'col-lg-12 btn btn-lg btn-primary' do
+                span.glyphicon.glyphicon-zoom-in aria-hidden='true'
+    .row
+      .col-xs-12.text-right
+        = link_to 'Advanced Search', '/'
+
+.row.group-details__row
+  .col-xs-6
+    h4= "#{@results.count} Results"
+  .col-xs-6.text-right
+    h4= 'Sort:'
+
+.row
+  .col-md-2
+    .summary-card
+      .summary-card__body
+        .summary-card__row.text-center
+          h5 FILTER
+  .col-md-10
+    - if @results.any?
+      - @results.records.each_with_hit do |result, hit|
+        = render 'shared/summary_cards/main', resource: result, hit: hit
+    - else
+      = 'No results found.'

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -4,6 +4,8 @@
       h5
         span.glyphicon.glyphicon-th-large.glyphicon--right
         = resource.name
+        - if defined?(hit) 
+          = " (Score: #{hit._score})"
     .summary-card__row.summary-card__row--min-height
       p
         strong ABOUT 

--- a/app/views/shared/summary_cards/_list.html.slim
+++ b/app/views/shared/summary_cards/_list.html.slim
@@ -8,7 +8,11 @@
         span.glyphicon.glyphicon-list.glyphicon--right
         = '13 items'
       .summary-card__metadata
-        h5= resource.name
+        h5
+          span.glyphicon.glyphicon-list.glyphicon--right
+          = resource.name
+          - if defined?(hit) 
+            = " (Score: #{hit._score})"
       .clearfix
     .summary-card__row--last
       p

--- a/app/views/shared/summary_cards/_main.html.slim
+++ b/app/views/shared/summary_cards/_main.html.slim
@@ -1,4 +1,4 @@
 - if partial = summary_card_for(resource)
-  = render partial, resource: resource
+  = render partial, resource: resource, hit: defined?(hit) ? hit : nil
 - else
   p Unsupported Summary Card Type

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -7,6 +7,8 @@
       h5
         span.glyphicon.glyphicon-file.glyphicon--right
         = resource.title
+        - if defined?(hit) 
+          = " (Score: #{hit._score})"
     .summary-card__row
       p
         | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   end
 
   resources :search, only: [:new]
+  get '/search', to: 'search#show', as: 'search'
 
   resources :resources, only: [:show]
 

--- a/spec/feature/user_manages_groups_spec.rb
+++ b/spec/feature/user_manages_groups_spec.rb
@@ -48,7 +48,7 @@ RSpec.feature 'Managing groups' do
     visit group_path(group)
     click_on 'MEMBERS'
 
-    within('#add-member-form') do
+    within('#top-page-form') do
       fill_in 'email', with: new_member.email
       click_on 'add-member-button'
     end

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Searching for resources', :worker, :elasticsearch do
   context 'when searching by title' do
-    scenario 'users should see metadata for a resource when search' do
+    scenario 'users can find a resource when searching' do
       title = Faker::Hipster.sentence
       metadata = { creators: 'Rachel Carson', date: Time.zone.today }
       create(:resource, title: title, metadata: metadata)
@@ -76,7 +76,7 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
       expect(page).to have_text(metadata[:date])
     end
 
-    scenario 'users should not see search results for deleted files' do
+    scenario 'users cannot see search results for deleted files' do
       title = Faker::Hipster.sentence
       metadata = { creators: 'Rachel Carson', date: Time.zone.today }
       resource = create(:resource, title: title, metadata: metadata)
@@ -91,8 +91,6 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
       end
 
       expect(page).not_to have_text(title)
-      expect(page).not_to have_text(metadata[:creators])
-      expect(page).not_to have_text(metadata[:date])
     end
   end
 end

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -15,8 +15,6 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
       end
 
       expect(page).to have_text(title)
-      expect(page).to have_text(metadata[:creators])
-      expect(page).to have_text(metadata[:date])
     end
 
     scenario 'users should see updated search results' do
@@ -49,8 +47,8 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
     end
 
     scenario "users should see updated search results even if the record wasn't indexed" do
-      title = 'Twitter'
-      new_title = 'Facebook'
+      title = 'Spotify'
+      new_title = 'Deezer'
       metadata = { creators: 'Rachel Carson', date: Time.zone.today }
 
       resource = create(:resource, title: title, metadata: metadata)
@@ -72,8 +70,28 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
       end
 
       expect(page).to have_text(new_title)
-      expect(page).to have_text(metadata[:creators])
-      expect(page).to have_text(metadata[:date])
+    end
+
+    scenario 'users can search for resources, groups and lists' do
+      title = Faker::Hipster.sentence
+
+      resource = create(:resource, title: "#{title} My Resource")
+      group = create(:group, name: "#{title} My Group")
+      list = create(:list, name: "#{title} My List")
+
+      wait_for {
+        Elasticsearch::Model.search(title, [Resource, Group, List]).results.total
+      }.to eq(3)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: title
+        click_button 'Search'
+      end
+
+      expect(page).to have_text('My Resource')
+      expect(page).to have_text('My Group')
+      expect(page).to have_text('My List')
     end
 
     scenario 'users cannot see search results for deleted files' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,7 +24,7 @@ RSpec.configure do |config|
   end
 
   config.before(:each, elasticsearch: true) do
-    reset_resource_index
+    reset_all_indices
   end
 
   config.around(:each, search_indexing_callbacks: false) do |example|
@@ -39,7 +39,7 @@ RSpec.configure do |config|
     end
   end
 
-  def reset_resource_index
+  def reset_all_indices
     [Resource, List, Group].each do |klass|
       klass.__elasticsearch__.delete_index!(index: klass.index_name)
       klass.__elasticsearch__.create_index!(index: klass.index_name)

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -18,7 +18,9 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   config.before(:suite) do
-    Resource.__elasticsearch__.create_index!(index: Resource.index_name)
+    [Resource, List, Group].each do |klass|
+      klass.__elasticsearch__.create_index!(index: klass.index_name)
+    end
   end
 
   config.before(:each, elasticsearch: true) do
@@ -38,7 +40,9 @@ RSpec.configure do |config|
   end
 
   def reset_resource_index
-    Resource.__elasticsearch__.delete_index!(index: Resource.index_name)
-    Resource.__elasticsearch__.create_index!(index: Resource.index_name)
+    [Resource, List, Group].each do |klass|
+      klass.__elasticsearch__.delete_index!(index: klass.index_name)
+      klass.__elasticsearch__.create_index!(index: klass.index_name)
+    end
   end
 end


### PR DESCRIPTION
Related issue: #98 (Points 1 and 2)

This pull request adds a simple search result page, stripped down from any complexity that will be added in future pull requests. There are many small changes on the front-end side, which made sense to make this PR stands on its own.

The ElasticSearch score was added for each record, I don't think this will be the final value being shown but it's a start. There is no filtering, no sorting and no pagination for now.

I'm also wondering if we should add [Font Awesome](http://fontawesome.io/) to the project to replace the very limited amount of icons coming with Bootstrap.

## Screenshots

![screen shot 2560-01-22 at 11 53 44 pm](https://cloud.githubusercontent.com/assets/2647689/22184140/9e7d108e-e0fe-11e6-8f7e-e118ed51c94b.png)
