### PR TITLE
Change Rubocop rake task to use .rubocop config

### DIFF
--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -4,8 +4,6 @@ if Rails.env.test?
   desc 'Run Rubocop to lint code and enforce style guide'
 
   task :rubocop do
-    require 'rubocop'
-    cli = RuboCop::CLI.new
-    cli.run(%w(--rails))
+    RuboCop::RakeTask.new
   end
 end


### PR DESCRIPTION
Currently, when running `bundle exec rake` (which runs `rspec` and the `rubocop` rake task), we are getting offenses that should be ignored by the configuration defined in [.rubocop.yml](https://github.com/greencommons/commons/blob/fix-rubocop-rake-task/.rubocop.yml).

Changing this rake task to use `RuboCop::RakeTask.new` seems to fix the issue.