### PR TITLE
Show score as colored label

### DIFF
--- a/app/helpers/score_helper.rb
+++ b/app/helpers/score_helper.rb
@@ -1,0 +1,11 @@
+module ScoreHelper
+  def score_class(score)
+    if score > 1
+      'label-success'
+    elsif score > 0.5
+      'label-warning'
+    else
+      'label-danger'
+    end
+  end
+end

--- a/app/views/shared/components/_score.html.slim
+++ b/app/views/shared/components/_score.html.slim
@@ -1,0 +1,3 @@
+- if hit
+  span.label class=(score_class(hit._score))
+    = " Relevancy: #{(hit._score).round(3)}"

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -4,8 +4,7 @@
       h5
         span.glyphicon.glyphicon-th-large.glyphicon--right
         = link_to resource.name, resource
-        - if defined?(hit) && hit
-          = " (Score: #{hit._score})"
+      = render 'shared/components/score', hit: hit if defined?(hit)
     .summary-card__row.summary-card__row--min-height
       p
         strong ABOUT 

--- a/app/views/shared/summary_cards/_list.html.slim
+++ b/app/views/shared/summary_cards/_list.html.slim
@@ -11,8 +11,7 @@
         h5
           span.glyphicon.glyphicon-list.glyphicon--right
           = resource.name
-          - if defined?(hit) && hit
-            = " (Score: #{hit._score})"
+        = render 'shared/components/score', hit: hit if defined?(hit)
       .clearfix
     .summary-card__row--last
       p

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -3,12 +3,10 @@
     .summary-card__row
       .summary-card__more
         = render 'shared/components/btn_count', path: '#', icon: 'plus', label: '10', style: 'primary'
-        
       h5
         span.glyphicon.glyphicon-file.glyphicon--right
         = link_to resource.title, resource
-        - if defined?(hit) && hit
-          = " (Score: #{hit._score})"
+      = render 'shared/components/score', hit: hit if defined?(hit)
     .summary-card__row
       p
         | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum 


### PR DESCRIPTION
This pull request improves the way the score is displayed in the search results. It is now using colored labels depending on the value:

- `score > 1` :  Green
- `score > 0.5` : Orange
- `score > 0` : Red

I tried to change the scores to be percent but wasn't able to. I thought the returned score was only between 0 and 1, which would have been easy to translate to percent. However, ES can return higher score values and doesn't seem to have a maximum. The second option I thought about was to use the top score as 100% but this seems not to be encouraged based on what I read [here](http://stackoverflow.com/questions/3986220/how-do-i-normalise-a-solr-lucene-score). I wasn't able to find any more examples than this about switching to percent and left it to ES score for now, with a `round(3)` to avoid loooong numbers.

## Screenshot

![screen shot 2560-02-02 at 11 36 03 am](https://cloud.githubusercontent.com/assets/2647689/22537377/afc37310-e93c-11e6-968f-2cff4b125a25.png)
