### PR TITLE
Suggestions for search and resource based on tags

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,11 @@ AllCops:
 Metrics/LineLength:
   Max: 100
   Enabled: true
+Metrics/BlockLength:
+  Exclude:
+      - 'config/routes.rb'
+      - 'spec/**/*.rb'
+      - '**/*.rake'
 Style/FrozenStringLiteralComment:
   Enabled: false
   EnforcedStyle: when_needed
@@ -27,11 +32,6 @@ Style/FrozenStringLiteralComment:
     - always
 Style/MultilineOperationIndentation:
   Enabled: false
-Style/BlockLength:
-  Exclude:
-      - 'config/routes.rb'
-      - 'spec/**/*.rb'
-      - '**/*.rake'
 Style/StringLiterals:
   EnforcedStyle: single_quotes
   SupportedStyles:

--- a/app/assets/javascripts/components/tags.jsx
+++ b/app/assets/javascripts/components/tags.jsx
@@ -75,8 +75,8 @@ var Tags = React.createClass({
             <span className="glyphicon glyphicon-tag glyphicon--right"></span>
             {this.state.tags.map(function(tag, i) {
               return (
-                <span key={tag.name}>
-                  <a href="/">{tag.name}</a>
+                <span key={tag}>
+                  <a href={'/search?query=' + tag}>{tag}</a>
                   {i == _this.state.tags.length - 1 ? '' : ', '}
                 </span>
               )

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -2,8 +2,9 @@ class ResourcesController < ApplicationController
   before_action :set_resource, only: [:show]
 
   def show
-    # TODO: Switch this to suggestion mechanism once implemented
-    @suggestions = Group.limit(6)
+    @suggestions = Suggesters::Tags.new(tags: @resource.tag_list,
+                                        except: @resource,
+                                        limit: 6).suggest
   end
 
   private

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -2,7 +2,7 @@ class ResourcesController < ApplicationController
   before_action :set_resource, only: [:show]
 
   def show
-    @suggestions = Suggesters::Tags.new(tags: @resource.tag_list,
+    @suggestions = Suggesters::Tags.new(tags: @resource.cached_tags,
                                         except: @resource,
                                         limit: 6).suggest
   end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -18,6 +18,12 @@ class SearchController < ApplicationController
     else
       @results = []
     end
+
+    if @results.any?
+      @suggestions = Suggesters::Tags.new(tags: @results.records.first.tag_list,
+                                          except: @results.records,
+                                          limit: 6).suggest
+    end
   end
 
   private

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -20,7 +20,8 @@ class SearchController < ApplicationController
     end
 
     if @results.any?
-      @suggestions = Suggesters::Tags.new(tags: @results.records.first.tag_list,
+      tags = @results.records.map(&:cached_tags).flatten.compact.uniq
+      @suggestions = Suggesters::Tags.new(tags: tags,
                                           except: @results.records,
                                           limit: 6).suggest
     end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -7,7 +7,7 @@ class TagsController < ApplicationController
       entity.tag_list.add(tag_params[:name])
       entity.save
 
-      render json: entity.tags
+      render json: entity.cached_tags
     else
       render json: { error: 'Unsupported Model Name.' }
     end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -10,9 +10,9 @@ module Indexable
     end
 
     after_commit on: [:update] do
-      _changes = previous_changes.dup
-      _changes['tags'] = _changes.delete('cached_tags')
-      UpdateIndexJob.perform_async(self.class.name, id, _changes.keys)
+      changes = previous_changes.dup
+      changes['tags'] =  changes.delete('cached_tags')
+      UpdateIndexJob.perform_async(self.class.name, id, changes.keys)
     end
 
     after_commit on: [:destroy] do

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -10,17 +10,13 @@ module Indexable
     end
 
     after_commit on: [:update] do
-      UpdateIndexJob.perform_async(self.class.name, id, previous_changes.keys)
+      _changes = previous_changes.dup
+      _changes['tags'] = _changes.delete('cached_tags')
+      UpdateIndexJob.perform_async(self.class.name, id, _changes.keys)
     end
 
     after_commit on: [:destroy] do
       RemoveFromIndexJob.perform_async(self.class.name, id)
     end
-  end
-
-  def as_indexed_json(_options = {})
-    as_json.merge(
-      'tags' => tag_list
-    )
   end
 end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -17,4 +17,10 @@ module Indexable
       RemoveFromIndexJob.perform_async(self.class.name, id)
     end
   end
+
+  def as_indexed_json(_options = {})
+    as_json.merge(
+      'tags' => tag_list
+    )
+  end
 end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -1,0 +1,17 @@
+module Taggable
+  extend ActiveSupport::Concern
+
+  included do
+    acts_as_taggable
+
+    after_touch do
+      update(cached_tags: tag_list)
+    end
+  end
+
+  def as_indexed_json(_options = {})
+    json = as_json
+    json['tags'] = json.delete('cached_tags')
+    json
+  end
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,9 +1,8 @@
 class Group < ApplicationRecord
   include Indexable
-  acts_as_taggable
+  include Taggable
 
   has_paper_trail
-  acts_as_taggable
 
   has_many :groups_users
   has_many :users, through: :groups_users

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,5 +1,6 @@
 class Group < ApplicationRecord
   include Indexable
+  acts_as_taggable
 
   has_paper_trail
   acts_as_taggable

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -1,8 +1,8 @@
 class List < ApplicationRecord
   include Indexable
+  include Taggable
 
   has_paper_trail
-  acts_as_taggable
 
   belongs_to :owner, polymorphic: true
   has_and_belongs_to_many :resources

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,6 +1,6 @@
 class Resource < ApplicationRecord
   include Indexable
-  acts_as_taggable
+  include Taggable
 
   RESOURCE_TYPES = {
     article: 0,
@@ -9,7 +9,6 @@ class Resource < ApplicationRecord
   }.freeze
 
   has_paper_trail
-  acts_as_taggable
 
   # Warning: since this is an enum (stored as an integer), we need to preserve the original integers
   # each value is associated with. Otherwise the types stored in the database will switch around.

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -1,5 +1,6 @@
 class Resource < ApplicationRecord
   include Indexable
+  acts_as_taggable
 
   RESOURCE_TYPES = {
     article: 0,

--- a/app/service/suggesters/tags.rb
+++ b/app/service/suggesters/tags.rb
@@ -1,0 +1,38 @@
+module Suggesters
+  class Tags
+    def initialize(tags:, except: [], limit: 10, models: [Group, List, Resource])
+      @tags = tags
+      @except = [*except]
+      @limit = limit
+      @models = models
+    end
+
+    def suggest
+      load_es_params
+      except_records if @except
+      Elasticsearch::Model.search(@es_params, @models).records
+    end
+
+    private
+
+    def load_es_params
+      @es_params = {
+        from: 0,
+        size: @limit,
+        query: {
+          bool: {
+            filter: {
+              terms: { tags: @tags }
+            },
+          }
+        }
+      }
+    end
+
+    def except_records
+      @es_params[:query][:bool][:must_not] ||= {
+        terms: { _id: @except.map(&:id) }
+      }
+    end
+  end
+end

--- a/app/services/suggesters/tags.rb
+++ b/app/services/suggesters/tags.rb
@@ -1,6 +1,6 @@
 module Suggesters
   class Tags
-    def initialize(tags:, except: [], limit: 10, models: [Group, List, Resource])
+    def initialize(tags:, except: [], limit: 10, models: [Group, Resource])
       @tags = tags
       @except = [*except]
       @limit = limit
@@ -22,7 +22,7 @@ module Suggesters
         query: {
           bool: {
             filter: {
-              terms: { tags: @tags }
+              terms: { tags: ['ocean'] }
             },
           }
         }
@@ -30,9 +30,10 @@ module Suggesters
     end
 
     def except_records
-      @es_params[:query][:bool][:must_not] ||= {
-        terms: { _id: @except.map(&:id) }
-      }
+      @es_params[:query][:bool][:must_not] ||= [
+        { terms: { _id: @except.map(&:id) } },
+        { terms: { type: @except.map { |e| e.class.name.downcase } } }
+      ]
     end
   end
 end

--- a/app/services/suggesters/tags.rb
+++ b/app/services/suggesters/tags.rb
@@ -22,7 +22,7 @@ module Suggesters
         query: {
           bool: {
             filter: {
-              terms: { tags: ['ocean'] }
+              terms: { tags: @tags }
             },
           }
         }

--- a/app/services/suggesters/tags.rb
+++ b/app/services/suggesters/tags.rb
@@ -1,6 +1,6 @@
 module Suggesters
   class Tags
-    def initialize(tags:, except: [], limit: 10, models: [Group, Resource])
+    def initialize(tags:, except: [], limit: 10, models: [Group, List, Resource])
       @tags = tags
       @except = [*except]
       @limit = limit

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -35,7 +35,7 @@
     .col-lg-12
       = react_component 'Tags', { authenticity_token: form_authenticity_token,
                                   submit_url: group_tags_path(@group),
-                                  tags: @group.tags,
+                                  tags: @group.cached_tags,
                                   can_create: @admin }, { prerender: true }
             
   .row
@@ -48,7 +48,7 @@
           .col-xs-12
             p
               span.glyphicon.glyphicon-text-color.glyphicon--right
-              = @group.long_description * 10
+              = @group.long_description
         .row
           .col-xs-12
             p

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -22,7 +22,7 @@
     .col-xs-12
       = react_component 'Tags', { authenticity_token: form_authenticity_token,
                                   submit_url: resource_tags_path(@resource),
-                                  tags: @resource.tags,
+                                  tags: @resource.cached_tags,
                                   can_create: true }, { prerender: true }
   
   .row

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -67,10 +67,4 @@
     .col-lg-12
       = render 'shared/components/discuss'
 
-  .row.page-details__row--half
-    .col-xs-12
-      h3 EXPLORE
-  .row
-    - @suggestions.each do |suggestion|
-      .col-xs-12.col-md-6
-        = render 'shared/summary_cards/main', resource: suggestion
+  = render 'shared/components/explore', suggestions: @suggestions

--- a/app/views/search/show.html.slim
+++ b/app/views/search/show.html.slim
@@ -66,3 +66,5 @@
 .row.page-details__row
   .col-xs-12.text-center
     = paginate @results
+
+= render 'shared/components/explore', suggestions: @suggestions, title: 'You may also like...'

--- a/app/views/shared/components/_explore.html.slim
+++ b/app/views/shared/components/_explore.html.slim
@@ -1,0 +1,8 @@
+- unless suggestions.blank?
+  .row.page-details__row--half
+    .col-xs-12
+      h3= defined?(title) ? title : 'EXPLORE'
+  .row
+    - suggestions.each do |suggestion|
+      .col-xs-12.col-md-6
+        = render 'shared/summary_cards/main', resource: suggestion

--- a/app/views/shared/components/_tags_list.html.slim
+++ b/app/views/shared/components/_tags_list.html.slim
@@ -1,6 +1,6 @@
 p
   span.glyphicon.glyphicon-tag.glyphicon--right
   - tags.each_with_index do |tag, i|
-    = link_to tag.name, root_path
+    = link_to tag, search_path(query: tag)
     = ', ' unless i == tags.size - 1
   

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -10,7 +10,7 @@
         strong ABOUT 
         = resource.long_description
     .summary-card__row
-      = render 'shared/components/tags_list', tags: resource.tags
+      = render 'shared/components/tags_list', tags: resource.cached_tags
     .summary-card__row.summary-card__row--last 
       .summary-card__metadata
         p

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -14,7 +14,7 @@
         | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum 
         | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum
     .summary-card__row
-      = render 'shared/components/tags_list', tags: resource.tags
+      = render 'shared/components/tags_list', tags: resource.cached_tags
     .summary-card__row.summary-card__row--last 
       .summary-card__metadata
         p

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -1,2 +1,3 @@
 ActsAsTaggableOn.remove_unused_tags = true
 ActsAsTaggableOn.force_lowercase = true
+ActsAsTaggableOn::Tagging.belongs_to :taggable, polymorphic: true, touch: true

--- a/db/migrate/20170203021400_add_cached_tag_list_to_groups.rb
+++ b/db/migrate/20170203021400_add_cached_tag_list_to_groups.rb
@@ -1,0 +1,9 @@
+class AddCachedTagListToGroups < ActiveRecord::Migration[5.0]
+  def up
+    add_column :groups, :cached_tags, :text, array: true, default: []
+  end
+
+  def down
+    remove_column :groups, :cached_tags
+  end
+end

--- a/db/migrate/20170203021406_add_cached_tag_list_to_resources.rb
+++ b/db/migrate/20170203021406_add_cached_tag_list_to_resources.rb
@@ -1,0 +1,9 @@
+class AddCachedTagListToResources < ActiveRecord::Migration[5.0]
+  def up
+    add_column :resources, :cached_tags, :text, array: true, default: []
+  end
+
+  def down
+    remove_column :resources, :cached_tags
+  end
+end

--- a/db/migrate/20170204041142_add_cached_tags_to_lists.rb
+++ b/db/migrate/20170204041142_add_cached_tags_to_lists.rb
@@ -1,0 +1,9 @@
+class AddCachedTagsToLists < ActiveRecord::Migration[5.0]
+  def up
+    add_column :lists, :cached_tags, :text, array: true, default: []
+  end
+
+  def down
+    remove_column :lists, :cached_tags
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170203021406) do
+ActiveRecord::Schema.define(version: 20170204041142) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -38,12 +38,13 @@ ActiveRecord::Schema.define(version: 20170203021406) do
   end
 
   create_table "lists", force: :cascade do |t|
-    t.string   "name",        null: false
+    t.string   "name",                     null: false
     t.string   "description"
-    t.string   "owner_type",  null: false
-    t.integer  "owner_id",    null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.string   "owner_type",               null: false
+    t.integer  "owner_id",                 null: false
+    t.datetime "created_at",               null: false
+    t.datetime "updated_at",               null: false
+    t.text     "cached_tags", default: [],              array: true
     t.index ["owner_type", "owner_id"], name: "index_lists_on_owner_type_and_owner_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161210110323) do
+ActiveRecord::Schema.define(version: 20170203021406) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "groups", force: :cascade do |t|
-    t.string   "name",              null: false
+    t.string   "name",                           null: false
     t.string   "short_description"
     t.text     "long_description"
     t.string   "url"
     t.string   "email"
     t.json     "metadata"
-    t.datetime "created_at",        null: false
-    t.datetime "updated_at",        null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.text     "cached_tags",       default: [],              array: true
   end
 
   create_table "groups_users", force: :cascade do |t|
@@ -61,6 +62,7 @@ ActiveRecord::Schema.define(version: 20161210110323) do
     t.datetime "updated_at",                 null: false
     t.jsonb    "metadata",      default: {}, null: false
     t.jsonb    "content",       default: {}, null: false
+    t.text     "cached_tags",   default: [],              array: true
     t.index ["user_id"], name: "index_resources_on_user_id", using: :btree
   end
 

--- a/spec/feature/user_interacts_with_resources_spec.rb
+++ b/spec/feature/user_interacts_with_resources_spec.rb
@@ -1,0 +1,37 @@
+require 'rails_helper'
+
+RSpec.feature 'Interacting with resources', :worker, :elasticsearch do
+  scenario 'users can see a list of related records' do
+    user = feature_login
+
+    resource = create(:resource, title: 'My Resource')
+    protection_group = create(:group, name: 'Protection Group')
+    help_group = create(:group, name: 'Help Group')
+    helpful_list = create(:list, name: 'Helpful List')
+
+    resource.tag_list.add('ocean')
+    resource.tag_list.add('sky')
+    resource.save!
+
+    protection_group.tag_list.add('ocean')
+    protection_group.save!
+
+    help_group.tag_list.add('mountain')
+    help_group.save!
+
+    helpful_list.tag_list.add('sky')
+    helpful_list.save!
+
+    wait_for do
+      Suggesters::Tags.new(tags: ['ocean', 'sky']).suggest.size
+    end.to eq(3)
+
+    visit resource_path(resource)
+
+    expect(page).to have_content('My Resource')
+    expect(page).to have_content('EXPLORE')
+    expect(page).to have_content('Protection Group')
+    expect(page).to have_content('Helpful List')
+    expect(page).not_to have_content('Help Group')
+  end
+end

--- a/spec/feature/user_interacts_with_resources_spec.rb
+++ b/spec/feature/user_interacts_with_resources_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Interacting with resources', :worker, :elasticsearch do
   scenario 'users can see a list of related records' do
-    user = feature_login
+    feature_login
 
     resource = create(:resource, title: 'My Resource')
     protection_group = create(:group, name: 'Protection Group')
@@ -23,7 +23,7 @@ RSpec.feature 'Interacting with resources', :worker, :elasticsearch do
     helpful_list.save!
 
     wait_for do
-      Suggesters::Tags.new(tags: ['ocean', 'sky']).suggest.size
+      Suggesters::Tags.new(tags: %w(ocean sky)).suggest.size
     end.to eq(3)
 
     visit resource_path(resource)

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -236,7 +236,7 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
       helpful_list.save!
 
       wait_for do
-        Suggesters::Tags.new(tags: ['ocean', 'sky']).suggest.size
+        Suggesters::Tags.new(tags: %w(ocean sky)).suggest.size
       end.to eq(3)
 
       visit new_search_path

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -214,4 +214,42 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
       expect(page).to have_text(/.*My Resource.*My List.*My Group.*/)
     end
   end
+
+  context 'related records' do
+    scenario 'users can see related records' do
+      resource = create(:resource, title: 'My Resource')
+      protection_group = create(:group, name: 'Protection Group')
+      help_group = create(:group, name: 'Help Group')
+      helpful_list = create(:list, name: 'Helpful List')
+
+      resource.tag_list.add('ocean')
+      resource.tag_list.add('sky')
+      resource.save!
+
+      protection_group.tag_list.add('ocean')
+      protection_group.save!
+
+      help_group.tag_list.add('mountain')
+      help_group.save!
+
+      helpful_list.tag_list.add('sky')
+      helpful_list.save!
+
+      wait_for do
+        Suggesters::Tags.new(tags: ['ocean', 'sky']).suggest.size
+      end.to eq(3)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: 'My Resource'
+        click_button 'Search'
+      end
+
+      expect(page).to have_text('My Resource')
+      expect(page).to have_text('You may also like...')
+      expect(page).to have_text('Protection Group')
+      expect(page).to have_text('Helpful List')
+      expect(page).not_to have_text('Help Group')
+    end
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,6 +33,12 @@ RSpec.configure do |config|
     end
   end
 
+  config.around(:each, sidekiq: true) do |example|
+    Sidekiq::Testing.inline! do
+      example.run
+    end
+  end
+
   config.around(:each, :worker) do |example|
     Sidekiq::Testing.inline! do
       example.run

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -33,12 +33,6 @@ RSpec.configure do |config|
     end
   end
 
-  config.around(:each, sidekiq: true) do |example|
-    Sidekiq::Testing.inline! do
-      example.run
-    end
-  end
-
   config.around(:each, :worker) do |example|
     Sidekiq::Testing.inline! do
       example.run

--- a/spec/services/suggesters/tags_spec.rb
+++ b/spec/services/suggesters/tags_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Suggesters::Tags do
+  describe '#suggest' do
+    context 'with tags = ["ocean"]' do
+
+      it 'returns ', elasticsearch: true, sidekiq: true do
+        title = Faker::Hipster.sentence
+        group = create(:group, name: title)
+        group2 = create(:group, name: title)
+        resource = create(:resource, title: title)
+
+        group.tag_list.add('ocean')
+        group.save
+
+        resource.tag_list.add('ocean')
+        resource.save
+
+        wait_for { Suggesters::Tags.new(tags: ['ocean']).suggest.size }.to eq(2)
+        records = Suggesters::Tags.new(tags: ['ocean']).suggest
+
+        expect(records).to include(group)
+        expect(records).to include(resource)
+      end
+    end
+  end
+end

--- a/spec/services/suggesters/tags_spec.rb
+++ b/spec/services/suggesters/tags_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Suggesters::Tags do
   describe '#suggest' do
     context 'with tags = ["ocean"]' do
-      it 'returns ', elasticsearch: true, sidekiq: true do
+      it 'returns all matching records', elasticsearch: true, sidekiq: true do
         title = Faker::Hipster.sentence
         group = create(:group, name: title)
         create(:group, name: title)
@@ -20,6 +20,69 @@ RSpec.describe Suggesters::Tags do
 
         expect(records).to include(group)
         expect(records).to include(resource)
+      end
+    end
+
+    context 'with tags = ["ocean"], except = group' do
+      it 'returns all matching records except the specified group', elasticsearch: true, sidekiq: true do
+        title = Faker::Hipster.sentence
+        group = create(:group, name: title)
+        create(:group, name: title)
+        resource = create(:resource, title: title)
+
+        group.tag_list.add('ocean')
+        group.save
+
+        resource.tag_list.add('ocean')
+        resource.save
+
+        wait_for { Suggesters::Tags.new(tags: ['ocean']).suggest.size }.to eq(2)
+        records = Suggesters::Tags.new(tags: ['ocean'], except: group).suggest
+
+        expect(records).not_to include(group)
+        expect(records).to include(resource)
+      end
+    end
+
+    context 'with tags = ["ocean"], limit = 1' do
+      it 'returns only one matching record', elasticsearch: true, sidekiq: true do
+        title = Faker::Hipster.sentence
+        group = create(:group, name: title)
+        create(:group, name: title)
+        resource = create(:resource, title: title)
+
+        group.tag_list.add('ocean')
+        group.save
+
+        resource.tag_list.add('ocean')
+        resource.save
+
+        wait_for { Suggesters::Tags.new(tags: ['ocean']).suggest.size }.to eq(2)
+        records = Suggesters::Tags.new(tags: ['ocean'], limit: 1).suggest
+
+        expect(records).to include(group)
+        expect(records).not_to include(resource)
+      end
+    end
+
+    context 'with tags = ["ocean"], models = [Group]' do
+      it 'returns only Group records', elasticsearch: true, sidekiq: true do
+        title = Faker::Hipster.sentence
+        group = create(:group, name: title)
+        create(:group, name: title)
+        resource = create(:resource, title: title)
+
+        group.tag_list.add('ocean')
+        group.save
+
+        resource.tag_list.add('ocean')
+        resource.save
+
+        wait_for { Suggesters::Tags.new(tags: ['ocean']).suggest.size }.to eq(2)
+        records = Suggesters::Tags.new(tags: ['ocean'], models: [Group]).suggest
+
+        expect(records).to include(group)
+        expect(records).not_to include(resource)
       end
     end
   end

--- a/spec/services/suggesters/tags_spec.rb
+++ b/spec/services/suggesters/tags_spec.rb
@@ -3,7 +3,7 @@ require 'rails_helper'
 RSpec.describe Suggesters::Tags do
   describe '#suggest' do
     context 'with tags = ["ocean"]' do
-      it 'returns all matching records', elasticsearch: true, sidekiq: true do
+      it 'returns all matching records', :worker, :elasticsearch do
         title = Faker::Hipster.sentence
         group = create(:group, name: title)
         create(:group, name: title)
@@ -25,7 +25,7 @@ RSpec.describe Suggesters::Tags do
 
     context 'with tags = ["ocean"], except = group' do
       it 'returns all matching records except the specified group',
-         elasticsearch: true, sidekiq: true do
+         :worker, :elasticsearch do
         title = Faker::Hipster.sentence
         group = create(:group, name: title)
         create(:group, name: title)
@@ -46,7 +46,7 @@ RSpec.describe Suggesters::Tags do
     end
 
     context 'with tags = ["ocean"], limit = 1' do
-      it 'returns only one matching record', elasticsearch: true, sidekiq: true do
+      it 'returns only one matching record', :worker, :elasticsearch do
         title = Faker::Hipster.sentence
         group = create(:group, name: title)
         create(:group, name: title)
@@ -66,7 +66,7 @@ RSpec.describe Suggesters::Tags do
     end
 
     context 'with tags = ["ocean"], models = [Group]' do
-      it 'returns only Group records', elasticsearch: true, sidekiq: true do
+      it 'returns only Group records', :worker, :elasticsearch do
         title = Faker::Hipster.sentence
         group = create(:group, name: title)
         create(:group, name: title)

--- a/spec/services/suggesters/tags_spec.rb
+++ b/spec/services/suggesters/tags_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Suggesters::Tags do
     end
 
     context 'with tags = ["ocean"], except = group' do
-      it 'returns all matching records except the specified group', elasticsearch: true, sidekiq: true do
+      it 'returns all matching records except the specified group',
+         elasticsearch: true, sidekiq: true do
         title = Faker::Hipster.sentence
         group = create(:group, name: title)
         create(:group, name: title)

--- a/spec/services/suggesters/tags_spec.rb
+++ b/spec/services/suggesters/tags_spec.rb
@@ -3,11 +3,10 @@ require 'rails_helper'
 RSpec.describe Suggesters::Tags do
   describe '#suggest' do
     context 'with tags = ["ocean"]' do
-
       it 'returns ', elasticsearch: true, sidekiq: true do
         title = Faker::Hipster.sentence
         group = create(:group, name: title)
-        group2 = create(:group, name: title)
+        create(:group, name: title)
         resource = create(:resource, title: title)
 
         group.tag_list.add('ocean')

--- a/spec/services/suggesters/tags_spec.rb
+++ b/spec/services/suggesters/tags_spec.rb
@@ -61,8 +61,7 @@ RSpec.describe Suggesters::Tags do
         wait_for { Suggesters::Tags.new(tags: ['ocean']).suggest.size }.to eq(2)
         records = Suggesters::Tags.new(tags: ['ocean'], limit: 1).suggest
 
-        expect(records).to include(group)
-        expect(records).not_to include(resource)
+        expect(records.count).to eq 1
       end
     end
 


### PR DESCRIPTION
Issue: #98 & #99 
Depends on PR #118 for tags and PR #117 for the correct version of ES in CircleCI (hence the failing tests).

# To do

- [x] Add feature tests
- [x] Ensure that the `Suggester::Tags` works correctly on the search page

# Explore / You may also like Section

This pull request adds the __Explore__ section to resources and the __You may also like__ section containing up to 6 suggestions based on the records tags.

I had quite a few issues with ES indexing since the tags are store in external tables. At first, I tried using the caching system from `acts-as-taggable-on` but it was so damn buggy that I switch to a custom and simple one. 

# Changes

- All the tags of the searched records are now used to find related records
- Clicking on a tag will take you to the search page with that tag as the query
- Feature specs for related records on search and resource pages
- Use of `cached_tags` everywhere to speed things up and prevent tons of queries