### PR TITLE
Make titles in summary cards link to the record

### DIFF
--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -3,7 +3,7 @@
     .summary-card__row
       h5
         span.glyphicon.glyphicon-th-large.glyphicon--right
-        = resource.name
+        = link_to resource.name, resource
         - if defined?(hit) && hit
           = " (Score: #{hit._score})"
     .summary-card__row.summary-card__row--min-height

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -6,7 +6,7 @@
         
       h5
         span.glyphicon.glyphicon-file.glyphicon--right
-        = resource.title
+        = link_to resource.title, resource
         - if defined?(hit) && hit
           = " (Score: #{hit._score})"
     .summary-card__row


### PR DESCRIPTION
The titles in the summary cards should link to the corresponding record page.