### PR TITLE
Resource Upload + CRUD

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -3,6 +3,7 @@
 @import "bootstrap";
 @import "theme/bootswatch";
 
+@import "helpers/colors";
 @import "helpers/glyphicons";
 @import "helpers/fonts";
 @import "helpers/text-aligning";

--- a/app/assets/stylesheets/components/_resource-actions.scss
+++ b/app/assets/stylesheets/components/_resource-actions.scss
@@ -1,8 +1,13 @@
 .resource-actions {
-  float: right;
+  float: left;
+  width: 100%;
 
   &__button--right {
-    margin-right: 20px;
+    margin-right: 10px;
+  }
+
+  &__button--bottom {
+    margin-bottom: 10px;
   }
 
   &__button--align-title {
@@ -12,4 +17,31 @@
   .badge {
     margin-left: 3px;
   }
+}
+
+/* Custom, iPhone Retina */
+@media only screen and (min-width : 320px) {
+}
+
+/* Extra Small Devices, Phones */
+@media only screen and (min-width : 480px) {
+
+}
+
+/* Small Devices, Tablets */
+@media only screen and (min-width : 768px) {
+  .resource-actions {
+    float: right;
+    width: auto;
+  }
+}
+
+/* Medium Devices, Desktops */
+@media only screen and (min-width : 992px) {
+
+}
+
+/* Large Devices, Wide Screens */
+@media only screen and (min-width : 1200px) {
+
 }

--- a/app/assets/stylesheets/components/_summary-card.scss
+++ b/app/assets/stylesheets/components/_summary-card.scss
@@ -35,6 +35,10 @@
     text-align: right;
   }
 
+  &__margin-right {
+    margin-right: 10px;
+  }
+
   &__more--space {
     margin-right: 30px;
   }

--- a/app/assets/stylesheets/components/_summary-card.scss
+++ b/app/assets/stylesheets/components/_summary-card.scss
@@ -23,6 +23,7 @@
   &__metadata {
     float: left;
     margin-right: 5%;
+    margin-bottom: 10px;
   }
 
   &__metadata--right {
@@ -30,9 +31,11 @@
     margin-right: 0;
   }
 
-  &__more {
-    float: right;
-    text-align: right;
+  &__metadata--link {
+    text-align: center;
+    margin-bottom: 10px;
+    float: left;
+    margin-right: 10px;
   }
 
   &__margin-right {
@@ -41,6 +44,16 @@
 
   &__more--space {
     margin-right: 30px;
+  }
+
+  &__top-actions, &__bottom-actions {
+    float: left;
+    width: 100%;
+  }
+
+  &__more {
+    text-align: center;
+    display: inline;
   }
 
   &__actions {
@@ -52,15 +65,59 @@
     text-align: left;
   }
 
+  &__title {
+    width: 100%;
+    margin-bottom: 20px;
+    line-height: 30px;
+  }
+
   .col-* {
     padding: 0;
   }
 
-  h5, p {
+  p {
     margin: 0;
   }
 
   img {
     width: 100%;
   }
+}
+
+/* Custom, iPhone Retina */
+@media only screen and (min-width : 320px) {
+  .summary-card {
+  }
+}
+
+/* Extra Small Devices, Phones */
+@media only screen and (min-width : 480px) {
+
+}
+
+/* Small Devices, Tablets */
+@media only screen and (min-width : 768px) {
+  .summary-card {
+    &__title {
+      width: auto;
+      float: left;
+      display: inline-block;
+    }
+
+    &__top-actions, &__bottom-actions {
+      width: auto;
+      float: right;
+      display: inline-block;
+    }
+  }
+}
+
+/* Medium Devices, Desktops */
+@media only screen and (min-width : 992px) {
+
+}
+
+/* Large Devices, Wide Screens */
+@media only screen and (min-width : 1200px) {
+
 }

--- a/app/assets/stylesheets/components/_summary-card.scss
+++ b/app/assets/stylesheets/components/_summary-card.scss
@@ -67,8 +67,12 @@
 
   &__title {
     width: 100%;
-    margin-bottom: 20px;
+    margin-bottom: 10px;
     line-height: 30px;
+  }
+
+  &__relevancy {
+    font-size: 16px;
   }
 
   .col-* {

--- a/app/assets/stylesheets/helpers/_colors.scss
+++ b/app/assets/stylesheets/helpers/_colors.scss
@@ -1,0 +1,3 @@
+.gray-light {
+  color: $gray-light;
+}

--- a/app/assets/stylesheets/helpers/_glyphicons.scss
+++ b/app/assets/stylesheets/helpers/_glyphicons.scss
@@ -5,3 +5,7 @@
 .glyphicon--left {
   margin-left: 10px;
 }
+
+.glyphicon--left-double {
+  margin-left: 20px;
+}

--- a/app/assets/stylesheets/pages/_default.scss
+++ b/app/assets/stylesheets/pages/_default.scss
@@ -1,6 +1,15 @@
 .page-details {
   $row-spacing: 30px;
 
+  h1, h3 {
+    margin-top: 0;
+  }
+
+  &__title {
+    font-size: 20px;
+    line-height: 30px;
+  }
+
   &__row {
     margin-bottom: $row-spacing;
   }
@@ -21,4 +30,34 @@
   &__tag-list {
     line-height: 37px;
   }
+}
+
+/* Custom, iPhone Retina */
+@media only screen and (min-width : 320px) {
+}
+
+/* Extra Small Devices, Phones */
+@media only screen and (min-width : 480px) {
+
+}
+
+/* Small Devices, Tablets */
+@media only screen and (min-width : 768px) {
+  .page-details {
+    &__title {
+      font-size: 40px;
+      line-height: 50px;
+      margin-top: 0;
+    }
+  }
+}
+
+/* Medium Devices, Desktops */
+@media only screen and (min-width : 992px) {
+
+}
+
+/* Large Devices, Wide Screens */
+@media only screen and (min-width : 1200px) {
+
 }

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,4 +1,5 @@
 class ResourcesController < ApplicationController
+  before_action :authenticate_user!, except: [:new, :create]
   before_action :set_resource, only: [:show]
 
   def show
@@ -7,10 +8,30 @@ class ResourcesController < ApplicationController
                                         limit: 6).suggest
   end
 
+  def new
+    @resource = Resource.new
+    authorize @resource
+  end
+
+  def create
+    @resource = Resource.new(resource_params)
+    authorize @resource
+
+    if @resource.save
+      redirect_to @resource, notice: 'Group was successfully created.'
+    else
+      render :new
+    end
+  end
+
   private
 
   def set_resource
     @resource = Resource.find(params[:id])
     authorize @resource
+  end
+
+  def resource_params
+    params.require(:resource).permit(:title)
   end
 end

--- a/app/controllers/resources_controller.rb
+++ b/app/controllers/resources_controller.rb
@@ -1,6 +1,10 @@
 class ResourcesController < ApplicationController
-  before_action :authenticate_user!, except: [:new, :create]
-  before_action :set_resource, only: [:show]
+  before_action :authenticate_user!, except: [:show]
+  before_action :set_resource, only: [:show, :edit, :update, :destroy, :leave]
+
+  def index
+    @resources = policy_scope(Resource).page(params[:page] || 1).per(10)
+  end
 
   def show
     @suggestions = Suggesters::Tags.new(tags: @resource.cached_tags,
@@ -13,15 +17,34 @@ class ResourcesController < ApplicationController
     authorize @resource
   end
 
+  def edit
+  end
+
   def create
     @resource = Resource.new(resource_params)
     authorize @resource
 
+    @resource.resource_type = :url
+    @resource.user = current_user
+
     if @resource.save
-      redirect_to @resource, notice: 'Group was successfully created.'
+      redirect_to @resource, notice: 'Resource was successfully created.'
     else
       render :new
     end
+  end
+
+  def update
+    if @resource.update(resource_params)
+      redirect_to @resource, notice: 'Resource was successfully updated.'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @resource.destroy
+    redirect_to resources_url, notice: 'Resource was successfully destroyed.'
   end
 
   private
@@ -32,6 +55,6 @@ class ResourcesController < ApplicationController
   end
 
   def resource_params
-    params.require(:resource).permit(:title)
+    params.require(:resource).permit(:title, :url)
   end
 end

--- a/app/helpers/glyphicon_helper.rb
+++ b/app/helpers/glyphicon_helper.rb
@@ -3,6 +3,7 @@ module GlyphiconHelper
     article: 'file',
     book: 'book',
     report: 'info-sign',
+    url: 'link'
   }.freeze
 
   def resource_icon(resource)

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -5,18 +5,26 @@ module Indexable
     include Elasticsearch::Model
     index_name SearchIndex.index_name(self)
 
+    def run_if_public(&block)
+      if self.respond_to?(:publ?) && self.publ?
+        block.call
+      end
+    end
+
     after_commit on: [:create] do
-      AddToIndexJob.perform_async(self.class.name, id)
+      run_if_public { AddToIndexJob.perform_async(self.class.name, id) }
     end
 
     after_commit on: [:update] do
-      changes = previous_changes.dup
-      changes['tags'] =  changes.delete('cached_tags')
-      UpdateIndexJob.perform_async(self.class.name, id, changes.keys)
+      run_if_public do
+        changes = previous_changes.dup
+        changes['tags'] =  changes.delete('cached_tags')
+        UpdateIndexJob.perform_async(self.class.name, id, changes.keys)
+      end
     end
 
     after_commit on: [:destroy] do
-      RemoveFromIndexJob.perform_async(self.class.name, id)
+      run_if_public { RemoveFromIndexJob.perform_async(self.class.name, id) }
     end
   end
 end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -6,9 +6,8 @@ module Indexable
     index_name SearchIndex.index_name(self)
 
     def run_if_public(&block)
-      if self.respond_to?(:publ?) && self.publ?
-        block.call
-      end
+      return if self.respond_to?(:priv?) && self.priv?
+      block.call
     end
 
     after_commit on: [:create] do

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -6,6 +6,12 @@ class Resource < ApplicationRecord
     article: 0,
     book: 1,
     report: 2,
+    url: 3
+  }.freeze
+
+  RESOURCE_PRIVACY_SETTINGS = {
+    priv: 0,
+    publ: 1
   }.freeze
 
   has_paper_trail
@@ -14,11 +20,13 @@ class Resource < ApplicationRecord
   # each value is associated with. Otherwise the types stored in the database will switch around.
   # See: http://www.justinweiss.com/articles/creating-easy-readable-attributes-with-activerecord-enums/
   enum resource_type: RESOURCE_TYPES
+  enum privacy: RESOURCE_PRIVACY_SETTINGS
 
   belongs_to :user, optional: true
   has_and_belongs_to_many :lists
 
   validates :title, :resource_type, presence: true
+  validates :url, length: { maximum: 255 }
 
   scope :sort_by_created_at, -> { order('created_at DESC') }
 end

--- a/app/policies/resource_policy.rb
+++ b/app/policies/resource_policy.rb
@@ -12,7 +12,7 @@ class ResourcePolicy < ApplicationPolicy
 
   def show?
     return true unless @resource.priv?
-    @resource.user == @user
+    @user && @resource.user == @user
   end
 
   def new?
@@ -24,15 +24,15 @@ class ResourcePolicy < ApplicationPolicy
   end
 
   def edit?
-    @resource.user == @user
+    @user && @resource.user == @user
   end
 
   def update?
-    @resource.user == @user
+    @user && @resource.user == @user
   end
 
   def destroy?
-    @resource.user == @user
+    @user && @resource.user == @user
   end
 
   def scope

--- a/app/policies/resource_policy.rb
+++ b/app/policies/resource_policy.rb
@@ -6,11 +6,42 @@ class ResourcePolicy < ApplicationPolicy
     @resource = resource
   end
 
+  def index?
+    @user
+  end
+
   def show?
-    true
+    return true unless @resource.priv?
+    @resource.user == @user
+  end
+
+  def new?
+    @user
+  end
+
+  def create?
+    @user
+  end
+
+  def edit?
+    @resource.user == @user
   end
 
   def update?
-    true
+    @resource.user == @user
+  end
+
+  def destroy?
+    @resource.user == @user
+  end
+
+  def scope
+    Pundit.policy_scope!(user, Resource)
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.where(user: user)
+    end
   end
 end

--- a/app/views/resources/_form.html.slim
+++ b/app/views/resources/_form.html.slim
@@ -1,0 +1,28 @@
+.row
+  .col-lg-8
+    .bs-component
+      = form_for(resource, html: { class: "form-horizontal" }) do |f|
+        - if resource.errors.any?
+          .alert.alert-warning role="alert"
+            p 
+              = pluralize(resource.errors.count, "error")
+              |  prohibited this resource from being saved.
+            ul
+              - resource.errors.full_messages.each do |message|
+                li= message
+        fieldset
+          .row
+            .col-xs-12
+              .form-group
+                = f.label :title, "TITLE", class: "col-lg-2 control-label"
+                .col-lg-10
+                  = f.text_field :title, class: "form-control", placeholder: "Resource Title"
+              .form-group
+                = f.label :url, "URL", class: "col-lg-2 control-label"
+                .col-lg-10
+                  = f.text_field :url, class: "form-control", placeholder: "Resource URL"  
+              .form-group
+                .col-lg-4.col-lg-offset-2
+                  = f.submit submit_label, class: "form-control btn btn-primary"
+                .col-lg-4
+                  = link_to "Back", cancel, class: "btn btn-default form-control"

--- a/app/views/resources/_form.html.slim
+++ b/app/views/resources/_form.html.slim
@@ -22,7 +22,7 @@
                 .col-lg-10
                   = f.text_field :url, class: "form-control", placeholder: "Resource URL"  
               .form-group
-                .col-lg-4.col-lg-offset-2
+                .col-lg-4.col-lg-offset-2.mb2
                   = f.submit submit_label, class: "form-control btn btn-primary"
                 .col-lg-4
                   = link_to "Back", cancel, class: "btn btn-default form-control"

--- a/app/views/resources/edit.html.slim
+++ b/app/views/resources/edit.html.slim
@@ -1,0 +1,4 @@
+.row
+  .col-lg-12 
+    h1 Edit #{@resource.title}
+    = render 'form', resource: @resource, submit_label: 'UPDATE', cancel: @resource

--- a/app/views/resources/index.html.slim
+++ b/app/views/resources/index.html.slim
@@ -1,0 +1,12 @@
+.row
+  .col-lg-12
+    h1 My Resources
+    
+    .row
+      - @resources.each do |resource|
+        .col-xs-12
+          = render "shared/summary_cards/main", resource: resource
+
+    .row.page-details__row
+      .col-xs-12.text-center
+        = paginate @resources

--- a/app/views/resources/new.html.slim
+++ b/app/views/resources/new.html.slim
@@ -2,5 +2,5 @@
   .col-lg-12 
     .row
       .col-xs-12
-        h1 Upload Resource
+        h1 Add Resource
     = render 'form', resource: @resource, submit_label: 'CREATE', cancel: resources_path

--- a/app/views/resources/new.html.slim
+++ b/app/views/resources/new.html.slim
@@ -1,0 +1,6 @@
+.row
+  .col-lg-12 
+    .row
+      .col-xs-12
+        h1 Upload Resource
+    = render 'form', resource: @resource, submit_label: 'CREATE', cancel: resources_path

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -1,25 +1,23 @@
 .page-details
   .row.page-details__row
-    .col-xs-4.col-md-4
+    .col-xs-4.col-sm-4
       h6
         span class="glyphicon glyphicon--right glyphicon-#{resource_icon(@resource)}"
         = @resource.resource_type.upcase
-    
-    .col-xs-8.col-md-8
+    .col-xs-12.col-sm-8
       .resource-actions
         = render 'shared/components/btn_count', path: '#', 
                                                 text: 'ADD TO LIST', 
                                                 label: @resource.lists.count,
-                                                classes: 'resource-actions__button--right',
+                                                classes: 'resource-actions__button resource-actions__button--bottom resource-actions__button--right',
                                                 style: 'primary'
         - if policy(@resource).edit?
           = link_to 'EDIT', edit_resource_path(@resource), class: 'btn btn-primary resource-actions__button--right'
         - if policy(@resource).destroy?
           = link_to 'DELETE', @resource, method: 'DELETE', class: 'btn btn-default resource-actions__button--right', data: { confirm: 'Are you sure?' }   
-        
   .row.page-details__row.page-details__row--half
     .col-xs-12
-      h1
+      h1.page-details__title
         - if @resource.priv?
           span class="glyphicon glyphicon--right glyphicon-eye-close"
         = @resource.title
@@ -70,12 +68,12 @@
         span.glyphicon.glyphicon-menu-up.glyphicon--left aria-hidden='true'
                     
   .row.page-details__row
-    .col-xs-12.col-sm-2
+    .col-xs-12.col-sm-4
       h3 CONTENT
-    .col-xs-12.col-sm-10
-      .resource-actions.resource-actions__button--align-title
-        = link_to 'VIEW ORIGINAL', '', class: 'resource-actions__button btn btn-primary resource-actions__button--right'
-        = link_to '', class: 'resource-actions__button btn btn-primary' do
+    .col-xs-12.col-sm-8
+      .resource-actions
+        = link_to 'VIEW ORIGINAL', '', class: 'resource-actions__button btn btn-primary resource-actions__button--bottom resource-actions__button--right'
+        = link_to '', class: 'resource-actions__button btn btn-primary resource-actions__button--bottom' do
           | EXPORT
           span.glyphicon.glyphicon-cloud-download.glyphicon--left aria-hidden='true'
           

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -3,7 +3,7 @@
     .col-xs-4.col-md-4
       h6
         span class="glyphicon glyphicon--right glyphicon-#{resource_icon(@resource)}"
-        = @resource.resource_type.capitalize
+        = @resource.resource_type.upcase
     
     .col-xs-8.col-md-8
       .resource-actions
@@ -12,11 +12,17 @@
                                                 label: @resource.lists.count,
                                                 classes: 'resource-actions__button--right',
                                                 style: 'primary'
-                                                
-
+        - if policy(@resource).edit?
+          = link_to 'EDIT', edit_resource_path(@resource), class: 'btn btn-primary resource-actions__button--right'
+        - if policy(@resource).destroy?
+          = link_to 'DELETE', @resource, method: 'DELETE', class: 'btn btn-default resource-actions__button--right', data: { confirm: 'Are you sure?' }   
+        
   .row.page-details__row.page-details__row--half
     .col-xs-12
-      h1= @resource.title
+      h1
+        - if @resource.priv?
+          span class="glyphicon glyphicon--right glyphicon-eye-close"
+        = @resource.title
 
   .row.page-details__row
     .col-xs-12
@@ -29,14 +35,24 @@
     .col-xs-12
       h3 ABOUT
       p
-        = @resource.content.truncate(800)
+        - if @resource.url?
+          .row
+            .col-xs-12
+              p= link_to @resource.url, @resource.url, target: '_blank'
+        - else
+          - if @resource.content.is_a?(String)
+            = @resource.content.truncate(800)
+          - else
+            = @resource.content
       #page-details__more.collapse
         .row
           .col-xs-12
             p
               span class="glyphicon glyphicon--right glyphicon-#{resource_icon(@resource)}"
-              = @resource.resource_type.capitalize
-              
+              = @resource.resource_type.upcase
+        - if @resource.priv?
+          = render 'resources/resource_metadata', metadata: 'Private', 
+                                                  icon: 'eye-close'
         = render 'resources/resource_metadata', metadata: humanize_str_date(@resource.metadata['date']), 
                                                 icon: 'calendar'
         = render 'resources/resource_metadata', metadata: @resource.metadata['creators'],

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -4,6 +4,10 @@
       h6
         span class="glyphicon glyphicon--right glyphicon-#{resource_icon(@resource)}"
         = @resource.resource_type.upcase
+        - if @resource.priv?
+          span.gray-light
+            span class="glyphicon glyphicon--left-double glyphicon--right glyphicon-eye-close"
+            | PRIVATE
     .col-xs-12.col-sm-8
       .resource-actions
         = render 'shared/components/btn_count', path: '#', 
@@ -18,8 +22,6 @@
   .row.page-details__row.page-details__row--half
     .col-xs-12
       h1.page-details__title
-        - if @resource.priv?
-          span class="glyphicon glyphicon--right glyphicon-eye-close"
         = @resource.title
 
   .row.page-details__row

--- a/app/views/shared/_nav.html.slim
+++ b/app/views/shared/_nav.html.slim
@@ -23,6 +23,7 @@ nav.navbar.navbar-inverse
               span.caret
             ul.dropdown-menu role='menu'
               li= link_to('My Profile', profile_path)
+              li= link_to('My Resources', resources_path)
               li= link_to('My Groups', groups_path)
               li= link_to('Logout', destroy_user_session_path)
       - else

--- a/app/views/shared/_nav.html.slim
+++ b/app/views/shared/_nav.html.slim
@@ -15,7 +15,7 @@ nav.navbar.navbar-inverse
               span.glyphicon.glyphicon-plus aria-hidden='true'
               span.caret
             ul.dropdown-menu role='menu'
-              li= link_to('Upload Resource', new_resource_path)
+              li= link_to('Add Resource', new_resource_path)
               li= link_to('Create Group', new_group_path)
           li.dropdown
             a.dropdown-toggle aria-expanded='false' data-toggle='dropdown' href='#' role='button'

--- a/app/views/shared/_nav.html.slim
+++ b/app/views/shared/_nav.html.slim
@@ -15,6 +15,7 @@ nav.navbar.navbar-inverse
               span.glyphicon.glyphicon-plus aria-hidden='true'
               span.caret
             ul.dropdown-menu role='menu'
+              li= link_to('Upload Resource', new_resource_path)
               li= link_to('Create Group', new_group_path)
           li.dropdown
             a.dropdown-toggle aria-expanded='false' data-toggle='dropdown' href='#' role='button'

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -1,11 +1,14 @@
 .summary-card
   .summary-card__body
-    .summary-card__row
-      h5
+    .summary-card__row--half
+      h5.summary-card__title
         span.glyphicon.glyphicon-th-large.glyphicon--right
         = link_to resource.name, resource
-      = render 'shared/components/score', hit: hit if defined?(hit)
-    .summary-card__row.summary-card__row--min-height
+        - if defined?(hit)
+          .summary-card__relevancy
+            = render 'shared/components/score', hit: hit  
+    .clearfix
+    .summary-card__row
       p
         strong ABOUT 
         = resource.long_description

--- a/app/views/shared/summary_cards/_list.html.slim
+++ b/app/views/shared/summary_cards/_list.html.slim
@@ -1,20 +1,25 @@
 .summary-card
   .summary-card__body
     .summary-card__row
-      .summary-card__more
-        span.glyphicon.glyphicon-calendar.glyphicon--right
-        = humanize_date(resource.created_at)
-      .summary-card__more.summary-card__more--space
+      h5.summary-card__title
         span.glyphicon.glyphicon-list.glyphicon--right
-        = '13 items'
-      .summary-card__metadata
-        h5
-          span.glyphicon.glyphicon-list.glyphicon--right
-          = resource.name
-        = render 'shared/components/score', hit: hit if defined?(hit)
-      .clearfix
-    .summary-card__row--last
+        = resource.name
+        - if defined?(hit)
+          .summary-card__relevancy
+            = render 'shared/components/score', hit: hit  
+    .clearfix
+    .summary-card__row
       p
         = resource.description
         | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum 
         | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum
+    .summary-card__row.summary-card__row--last 
+      .summary-card__metadata
+        p
+          span.glyphicon.glyphicon-calendar.glyphicon--right
+          = humanize_date(resource.created_at)
+      .summary-card__metadata
+        p
+          span.glyphicon.glyphicon-list.glyphicon--right
+          = '13 items'
+      .clearfix

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -1,11 +1,12 @@
 .summary-card
   .summary-card__body
-    .summary-card__row
+    .summary-card__row--half
       h5.summary-card__title
         span class="glyphicon glyphicon--right glyphicon-#{resource_icon(resource)}"
         = link_to resource.title, resource
-      = render 'shared/components/score', hit: hit if defined?(hit)
-
+        - if defined?(hit)
+          .summary-card__relevancy
+            = render 'shared/components/score', hit: hit 
       .summary-card__top-actions
         .summary-card__more.summary-card__margin-right
           = render 'shared/components/btn_count', path: '#', icon: 'plus', label: '10', style: 'primary'
@@ -18,6 +19,7 @@
             = link_to resource, method: 'DELETE', class: 'btn btn-default', data: { confirm: 'Are you sure?' } do
               span class="glyphicon  glyphicon-remove"
       .clearfix
+    
     .summary-card__row
       p
         - if resource.url?

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -1,21 +1,23 @@
 .summary-card
   .summary-card__body
     .summary-card__row
-      - if policy(resource).destroy?
-        .summary-card__more
-          = link_to resource, method: 'DELETE', class: 'btn btn-default', data: { confirm: 'Are you sure?' } do
-            span class="glyphicon  glyphicon-remove"
-      - if policy(resource).edit?
-        .summary-card__more.summary-card__margin-right
-          = link_to edit_resource_path(resource), class: 'btn btn-primary' do
-            span class="glyphicon  glyphicon-pencil"
-      .summary-card__more.summary-card__margin-right
-        = render 'shared/components/btn_count', path: '#', icon: 'plus', label: '10', style: 'primary'
-      
-      h5
+      h5.summary-card__title
         span class="glyphicon glyphicon--right glyphicon-#{resource_icon(resource)}"
         = link_to resource.title, resource
       = render 'shared/components/score', hit: hit if defined?(hit)
+
+      .summary-card__top-actions
+        .summary-card__more.summary-card__margin-right
+          = render 'shared/components/btn_count', path: '#', icon: 'plus', label: '10', style: 'primary'
+        - if policy(resource).edit?
+          .summary-card__more.summary-card__margin-right
+            = link_to edit_resource_path(resource), class: 'btn btn-primary' do
+              span class="glyphicon  glyphicon-pencil"
+        - if policy(resource).destroy?
+          .summary-card__more
+            = link_to resource, method: 'DELETE', class: 'btn btn-default', data: { confirm: 'Are you sure?' } do
+              span class="glyphicon  glyphicon-remove"
+      .clearfix
     .summary-card__row
       p
         - if resource.url?
@@ -27,7 +29,7 @@
             = resource.content
     .summary-card__row
       = render 'shared/components/tags_list', tags: resource.cached_tags
-    .summary-card__row.summary-card__row--last 
+    .summary-card__row
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-user.glyphicon--right
@@ -44,13 +46,13 @@
         p
           span.glyphicon.glyphicon-edit.glyphicon--right
           = link_to '102 Annotations', '#'
-      .summary-card__metadata.summary-card__metadata--right
-        = link_to 'Read More', resource, class: 'btn btn-default'
-      .summary-card__metadata.summary-card__metadata--right.summary-card__margin-right
-        = link_to 'View Original Document', '#', class: 'btn btn-default'
-      
+      .summary-card__bottom-actions
+        .summary-card__metadata.summary-card__metadata--link
+          = link_to 'View Original Document', '#', class: 'btn btn-default'
+        .summary-card__metadata.summary-card__metadata--link
+          = link_to 'Read More', resource, class: 'btn btn-default'
       .clearfix
-    
+
   .summary-card__actions.summary-card__actions--left
     p.italic
       | Added to 

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -1,18 +1,30 @@
 .summary-card
   .summary-card__body
     .summary-card__row
-      .summary-card__more
+      - if policy(resource).destroy?
+        .summary-card__more
+          = link_to resource, method: 'DELETE', class: 'btn btn-default', data: { confirm: 'Are you sure?' } do
+            span class="glyphicon  glyphicon-remove"
+      - if policy(resource).edit?
+        .summary-card__more.summary-card__margin-right
+          = link_to edit_resource_path(resource), class: 'btn btn-primary' do
+            span class="glyphicon  glyphicon-pencil"
+      .summary-card__more.summary-card__margin-right
         = render 'shared/components/btn_count', path: '#', icon: 'plus', label: '10', style: 'primary'
+      
       h5
-        span.glyphicon.glyphicon-file.glyphicon--right
+        span class="glyphicon glyphicon--right glyphicon-#{resource_icon(resource)}"
         = link_to resource.title, resource
       = render 'shared/components/score', hit: hit if defined?(hit)
     .summary-card__row
       p
-        | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum 
-        | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum
-        | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum 
-        | Lorem ipsum lorem ipsum lorem ipsum lorem ipsum
+        - if resource.url?
+          = link_to resource.url, resource.url, target: '_blank'
+        - else
+          - if resource.content.is_a?(String)
+            = resource.content.truncate(200)
+          - else
+            = resource.content
     .summary-card__row
       = render 'shared/components/tags_list', tags: resource.cached_tags
     .summary-card__row.summary-card__row--last 
@@ -33,7 +45,10 @@
           span.glyphicon.glyphicon-edit.glyphicon--right
           = link_to '102 Annotations', '#'
       .summary-card__metadata.summary-card__metadata--right
-        = link_to 'View Original Document', '#'
+        = link_to 'Read More', resource, class: 'btn btn-default'
+      .summary-card__metadata.summary-card__metadata--right.summary-card__margin-right
+        = link_to 'View Original Document', '#', class: 'btn btn-default'
+      
       .clearfix
     
   .summary-card__actions.summary-card__actions--left

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get '/profile/password', to: 'users/passwords#edit', as: 'password'
   patch '/profile/password', to: 'users/passwords#update', as: 'update_password'
 
-  resources :resources, model_name: 'Resource', concerns: :taggable, only: [:show]
+  resources :resources, model_name: 'Resource', concerns: :taggable, only: [:show, :new, :create]
 
   resources :groups, model_name: 'Group', concerns: :taggable do
     resources :members, only: [:index, :create, :destroy] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
   get '/profile/password', to: 'users/passwords#edit', as: 'password'
   patch '/profile/password', to: 'users/passwords#update', as: 'update_password'
 
-  resources :resources, model_name: 'Resource', concerns: :taggable, only: [:show, :new, :create]
+  resources :resources, model_name: 'Resource', concerns: :taggable
 
   resources :groups, model_name: 'Group', concerns: :taggable do
     resources :members, only: [:index, :create, :destroy] do

--- a/db/migrate/20170216150136_add_privacy_and_url_to_resources.rb
+++ b/db/migrate/20170216150136_add_privacy_and_url_to_resources.rb
@@ -1,0 +1,6 @@
+class AddPrivacyAndUrlToResources < ActiveRecord::Migration[5.0]
+  def change
+    add_column :resources, :privacy, :integer, default: 0, null: false
+    add_column :resources, :url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170216111242) do
+ActiveRecord::Schema.define(version: 20170216150136) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,8 @@ ActiveRecord::Schema.define(version: 20170216111242) do
     t.jsonb    "metadata",      default: {}, null: false
     t.jsonb    "content",       default: {}, null: false
     t.text     "cached_tags",   default: [],              array: true
+    t.integer  "privacy",       default: 0,  null: false
+    t.string   "url"
     t.index ["user_id"], name: "index_resources_on_user_id", using: :btree
   end
 

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -3,5 +3,6 @@ FactoryGirl.define do
     title { Faker::Book.title }
     resource_type { :book }
     content { Faker::Hipster.paragraph }
+    privacy 'publ'
   end
 end

--- a/spec/feature/user_manages_resources_spec.rb
+++ b/spec/feature/user_manages_resources_spec.rb
@@ -1,0 +1,63 @@
+require 'rails_helper'
+
+RSpec.feature 'Managing resources' do
+  scenario 'users can list resources' do
+    user = feature_login
+    resource = create(:resource, user: user)
+
+    click_link 'My Resources'
+    expect(find('h1')).to have_content('My Resources')
+    expect(page).to have_text(resource.title)
+  end
+
+  scenario 'users can view a resource' do
+    user = feature_login
+    resource = create(:resource, resource_type: :url, url: 'http://example.com', user: user)
+
+    click_link 'My Resources'
+    click_link resource.title
+
+    expect(page).to have_text('URL')
+    expect(page).to have_text('http://example.com')
+  end
+
+  scenario 'users can create a resource' do
+    user = feature_login
+    resource = build(:resource, resource_type: :url, url: 'http://example.com', user: user)
+
+    click_link 'Upload Resource'
+
+    within('#new_resource') do
+      fill_in 'resource[title]', with: resource.title
+      fill_in 'resource[url]', with: resource.url
+      click_on 'CREATE'
+    end
+
+    expect(find('h1')).to have_content(resource.title)
+    expect(Resource.count).to eq 1
+  end
+
+  scenario 'users can update a resource' do
+    user = feature_login
+    resource = create(:resource, resource_type: :url, url: 'http://example.com', user: user)
+
+    visit edit_resource_path(resource)
+    within("#edit_resource_#{resource.id}") do
+      fill_in 'resource[title]', with: 'Water Experiments'
+      click_on 'UPDATE'
+    end
+
+    expect(find('h1')).to have_content('Water Experiments')
+    expect(Resource.last.title).to eq 'Water Experiments'
+  end
+
+  scenario 'users can destroy a resource' do
+    user = feature_login
+    resource = create(:resource, resource_type: :url, url: 'http://example.com', user: user)
+
+    visit resource_path(resource)
+    click_link 'DELETE'
+
+    expect(Resource.count).to eq 0
+  end
+end

--- a/spec/feature/user_manages_resources_spec.rb
+++ b/spec/feature/user_manages_resources_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Managing resources' do
     user = feature_login
     resource = build(:resource, resource_type: :url, url: 'http://example.com', user: user)
 
-    click_link 'Upload Resource'
+    click_link 'Add Resource'
 
     within('#new_resource') do
       fill_in 'resource[title]', with: resource.title

--- a/spec/models/resource_spec.rb
+++ b/spec/models/resource_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Resource do
     let(:resource) { create(:resource, privacy: :priv) }
 
     describe 'after_commit on: [:create]' do
-      it "adds the #{name} to the search index after creation" do
+      it "does not add the #{name} to the search index after creation" do
         allow(AddToIndexJob).to receive(:perform_async)
 
         expect(AddToIndexJob).not_to have_received(:perform_async).
@@ -32,7 +32,7 @@ RSpec.describe Resource do
     end
 
     describe 'after_commit on: [:update]' do
-      it "updates the #{name} index in the search index after update" do
+      it "does not update the #{name} index in the search index after update" do
         allow(UpdateIndexJob).to receive(:perform_async)
 
         resource.touch
@@ -43,7 +43,7 @@ RSpec.describe Resource do
     end
 
     describe 'after_commit on: [:destroy]' do
-      it "removes the #{name} from the search index after deletion" do
+      it "does not remove the #{name} from the search index after deletion" do
         allow(RemoveFromIndexJob).to receive(:perform_async)
 
         resource.destroy

--- a/spec/policies/resource_policy_spec.rb
+++ b/spec/policies/resource_policy_spec.rb
@@ -9,11 +9,36 @@ describe ResourcePolicy do
     let(:user) { nil }
 
     it { is_expected.to permit_action(:show) }
+
+    it { is_expected.to forbid_action(:index)   }
+    it { is_expected.to forbid_action(:new)     }
+    it { is_expected.to forbid_action(:create)  }
+    it { is_expected.to forbid_action(:update)  }
+    it { is_expected.to forbid_action(:edit)    }
+    it { is_expected.to forbid_action(:destroy) }
   end
 
   context 'when user' do
     let(:user) { FactoryGirl.create(:user) }
 
     it { is_expected.to permit_action(:show) }
+    it { is_expected.to permit_action(:index)   }
+    it { is_expected.to permit_action(:new)     }
+    it { is_expected.to permit_action(:create)  }
+    it { is_expected.to forbid_action(:update)  }
+    it { is_expected.to forbid_action(:edit)    }
+    it { is_expected.to forbid_action(:destroy) }
+
+    context 'when owner' do
+      let(:resource) { FactoryGirl.create(:resource, user: user) }
+
+      it { is_expected.to permit_action(:show) }
+      it { is_expected.to permit_action(:index)   }
+      it { is_expected.to permit_action(:new)     }
+      it { is_expected.to permit_action(:create)  }
+      it { is_expected.to permit_action(:update)  }
+      it { is_expected.to permit_action(:edit)    }
+      it { is_expected.to permit_action(:destroy) }
+    end
   end
 end

--- a/spec/requests/resources_controller_spec.rb
+++ b/spec/requests/resources_controller_spec.rb
@@ -1,12 +1,132 @@
 require 'rails_helper'
 
 RSpec.describe 'Resources', type: :request do
+  let(:user) { create(:user) }
   let(:resource) { create(:resource) }
+  let(:valid_attributes) { attributes_for(:resource) }
+  let(:invalid_attributes) { attributes_for(:resource, title: nil) }
 
-  describe 'GET /resources/:id' do
-    it 'gets 200' do
-      get resource_path(resource)
-      expect(response).to have_http_status(200)
+  describe 'guest' do
+    describe 'GET /resources' do
+      it 'redirects to login page' do
+        get resources_path
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    describe 'GET /resources/:id' do
+      it 'gets 200' do
+        get resource_path(resource)
+        expect(response).to have_http_status(200)
+      end
+    end
+  end
+
+  describe 'logged in user' do
+    before { sign_in user }
+
+    describe 'GET /resources' do
+      it 'gets 200' do
+        get resources_path
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'GET /resources/new' do
+      it 'gets 200' do
+        get new_resource_path
+        expect(response).to have_http_status(200)
+      end
+    end
+
+    describe 'POST /resources' do
+      context 'valid attributes' do
+        it 'gets redirected to resources_path' do
+          post resources_path, params: { resource: valid_attributes }
+          expect(response).to redirect_to Resource.last
+        end
+
+        it 'creates the resource' do
+          post resources_path, params: { resource: valid_attributes }
+          expect(Resource.last.title).to eq valid_attributes[:title]
+        end
+      end
+
+      context 'invalid attributes' do
+        it 'does not redirect to resources_path' do
+          post resources_path, params: { resource: invalid_attributes }
+          expect(response).to have_http_status(200)
+        end
+
+        it 'does not create the resource' do
+          post resources_path, params: { resource: invalid_attributes }
+          expect(Resource.last).to be nil
+        end
+      end
+    end
+
+    describe 'GET /resources/edit' do
+      it 'gets 302' do
+        get edit_resource_path(resource)
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    describe 'PATCH /resources/:id' do
+      it 'gets 302' do
+        patch resource_path(resource)
+        expect(response).to have_http_status(302)
+      end
+    end
+
+    describe 'resource owner' do
+      let(:resource) { create(:resource, title: 'Nice Resource', user: user) }
+      before { sign_in user }
+
+      describe 'GET /resources/edit' do
+        it 'gets 200' do
+          get edit_resource_path(resource)
+          expect(response).to have_http_status(200)
+        end
+      end
+
+      describe 'PATCH /resources/:id' do
+        context 'valid attributes' do
+          it 'gets redirected to resources_path' do
+            patch resource_path(resource), params: { resource: { title: 'Better Resource' } }
+            expect(response).to redirect_to resource
+          end
+
+          it 'updates the resource' do
+            patch resource_path(resource), params: { resource: { title: 'Better Resource' } }
+            expect(Resource.last.title).to eq 'Better Resource'
+          end
+        end
+
+        context 'invalid attributes' do
+          it 'does not redirect to resources_path' do
+            patch resource_path(resource), params: { resource: { title: nil } }
+            expect(response).to have_http_status(200)
+          end
+
+          it 'does not update the resource' do
+            patch resource_path(resource), params: { resource: { title: nil } }
+            expect(Resource.last.title).to eq 'Nice Resource'
+          end
+        end
+      end
+
+      describe 'DELETE /resources/:id' do
+        it 'gets redirected to resources_path' do
+          delete resource_path(resource)
+          expect(response).to redirect_to resources_path
+        end
+
+        it 'deletes the resource' do
+          delete resource_path(resource)
+          expect(Resource.where(id: resource.id).first).to be nil
+        end
+      end
     end
   end
 end

--- a/spec/support/shared/indexable.rb
+++ b/spec/support/shared/indexable.rb
@@ -1,6 +1,6 @@
 RSpec.shared_examples 'indexable' do |name|
   describe 'Callbacks' do
-    describe 'after_save' do
+    describe 'after_commit on: [:create]' do
       it "adds the #{name} to the search index after creation" do
         allow(AddToIndexJob).to receive(:perform_async)
 
@@ -11,7 +11,19 @@ RSpec.shared_examples 'indexable' do |name|
       end
     end
 
-    describe 'after_destroy' do
+    describe 'after_commit on: [:update]' do
+      it "updates the #{name} index in the search index after update" do
+        allow(UpdateIndexJob).to receive(:perform_async)
+
+        record = create(name)
+        record.touch
+
+        expect(UpdateIndexJob).to have_received(:perform_async).
+          with(record.class.name, record.id, [])
+      end
+    end
+
+    describe 'after_commit on: [:destroy]' do
       it "removes the #{name} from the search index after deletion" do
         record = create(name)
         allow(RemoveFromIndexJob).to receive(:perform_async)


### PR DESCRIPTION
# Reason for Change

This pull request adds a way for users to upload resources (only URL type), listing the uploaded resources and managing them (basic CRUD).

# Changes

- Upload Resource: Logged in users can now click on `Upload Resource` in the dropdown menu to access a simple form (title + URL) to create a resource. That resource will be created with the current user as owner, the `resource_type` set to `url` and the privacy set to `priv` (private).
- My Resources: Just like `My Groups`, a user can access a page listing all the resources he has created. He can then view, edit or destroy them. 
- Privacy: A new enum was added to resources (`privacy`). It can either be set to `publ` or `priv` (default to `priv`) and can be used to prevent a resource from being seen by other users. Private resources are not indexed in ElasticSearch. `public` and `private` being reserved keywords in Ruby, I had to use `publ` and `priv` instead.
- Summary Card Changes: I started to improve the summary card design to make them more responsive. I'm planning to continue that effort in a future PR and apply it to all the summary cards. Some adjustments will also be made to some pages to improve the mobile experience.

# Notes

[Related Task](https://trello.com/c/quEqxdJF/13-green-commons-add-a-url-resource-upload-form)