### PR TITLE
Fix alignment issues when showing records 2 by 2

### DIFF
--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -1,8 +1,8 @@
 .row
   .col-lg-12
     h1 My Groups
-    
-    .row
-      - @groups.each do |group|
-        .col-xs-12.col-md-6
-          = render "shared/summary_cards/main", resource: group
+    - @groups.each_slice(2) do |slice|
+      .row 
+        - slice.each do |group|
+          .col-xs-12.col-md-6
+            = render "shared/summary_cards/main", resource: group

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -101,10 +101,11 @@
           .resource-actions
             = link_to 'NEW LIST', '#', class: 'btn btn-primary resource-actions__button--right resource-actions__button--align-title'
             = link_to 'ALL LISTS', '#', class: 'btn btn-primary resource-actions__button--align-title'
-      .row
-        - @group.lists.each do |list|
-          .col-lg-6
-            = render 'shared/summary_cards/main', resource: list
+      - @group.lists.each_slice(2) do |slice|
+        .row
+          - slice.each do |list|
+            .col-lg-6
+              = render 'shared/summary_cards/main', resource: list
             
   .row.page-details__row
     .col-lg-12

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -15,7 +15,9 @@
                                                 placeholder: 'Type member name or email',
                                                 authenticity_token: form_authenticity_token }, 
                                               { prerender: true })
-.row
-  - @members.each do |member|
-    .col-xs-12.col-lg-6
-      = render 'shared/summary_cards/main', resource: member
+
+- @members.each_slice(2) do |slice|
+  .row
+    - slice.each do |member|
+      .col-xs-12.col-lg-6
+        = render 'shared/summary_cards/main', resource: member

--- a/app/views/shared/components/_explore.html.slim
+++ b/app/views/shared/components/_explore.html.slim
@@ -2,7 +2,9 @@
   .row.page-details__row--half
     .col-xs-12
       h3= defined?(title) ? title : 'EXPLORE'
-  .row
-    - suggestions.each do |suggestion|
-      .col-xs-12.col-md-6
-        = render 'shared/summary_cards/main', resource: suggestion
+  
+  - suggestions.each_slice(2) do |slice|
+    .row
+      - slice.each do |suggestion|
+        .col-xs-12.col-md-6
+          = render 'shared/summary_cards/main', resource: suggestion


### PR DESCRIPTION
Related Issue: #122 

This pull request fixes the alignment issue we were having when displaying records two by two. To prevent the issue, we are now using `each_slice(2)` and adding the `.row` class for each line.