### PR TITLE
Fix Total Search Count

### DIFF
--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -15,6 +15,7 @@ class SearchController < ApplicationController
 
       @results = Elasticsearch::Model.search(*builder.to_elasticsearch).
                  page(params[:page] || 1).per(10)
+      @total_count = @results.results.total
     else
       @results = []
     end

--- a/app/views/search/show.html.slim
+++ b/app/views/search/show.html.slim
@@ -18,7 +18,7 @@
 = form_tag search_path, method: :get do
   .row.page-details__row--half
     .col-xs-12.col-sm-6.page-details__row
-      h4= "#{@results.count} Results"
+      h4= "#{@total_count} Results"
     .col-xs-12.col-sm-6
       .row
           .col-xs-8.col-sm-4.col-sm-offset-4


### PR DESCRIPTION
Related issue: #127 

This pull request fixes the displayed total number of results for a search. Until now, it was showing the count after pagination and made little sense. It should now be using the total number of records found in ES.