### PR TITLE
Add content and long_description to the fields searched by ES

### DIFF
--- a/app/services/search_builders/query.rb
+++ b/app/services/search_builders/query.rb
@@ -10,6 +10,8 @@ module SearchBuilders
 
       @es_params[:query][:bool][:must][:bool][:should] << { match: { title: @query } }
       @es_params[:query][:bool][:must][:bool][:should] << { match: { name: @query } }
+      @es_params[:query][:bool][:must][:bool][:should] << { match: { content: @query } }
+      @es_params[:query][:bool][:must][:bool][:should] << { match: { long_description: @query } }
 
       @es_params
     end


### PR DESCRIPTION
Related Issue: #128 

This pull request adds two fields to the ones being searched by ES when making a search on the website: `content` and `long_description`.

I will wait for an answer to my question on the issue so see if I should change the `match` queries to `match_phrase`. 