### PR TITLE
Generate published_at date after creation

### DIFF
--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -10,6 +10,8 @@ module Indexable
       yield
     end
 
+    after_create :set_published_at
+
     after_commit on: [:create] do
       run_if_public { AddToIndexJob.perform_async(self.class.name, id) }
     end
@@ -24,6 +26,16 @@ module Indexable
 
     after_commit on: [:destroy] do
       run_if_public { RemoveFromIndexJob.perform_async(self.class.name, id) }
+    end
+
+    def set_published_at
+      unless published_at
+        if defined?(metadata) && metadata && metadata['date']
+          update_column(:published_at, metadata['date'])
+        else
+          update_column(:published_at, created_at)
+        end
+      end
     end
   end
 end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -31,7 +31,11 @@ module Indexable
     def set_published_at
       unless published_at
         if defined?(metadata) && metadata && metadata['date']
-          update_column(:published_at, metadata['date'])
+          begin
+            update_column(:published_at, metadata['date'])
+          rescue ActiveRecord::StatementInvalid
+            update_column(:published_at, created_at)
+          end
         else
           update_column(:published_at, created_at)
         end

--- a/app/services/search_builders/sorter.rb
+++ b/app/services/search_builders/sorter.rb
@@ -1,7 +1,7 @@
 module SearchBuilders
   SORT_OPTIONS = {
-    recent: { col: :created_at, dir: :desc },
-    oldest: { col: :created_at, dir: :asc }
+    recent: { col: :published_at, dir: :desc },
+    oldest: { col: :published_at, dir: :asc }
   }.freeze
 
   class Sorter

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -18,7 +18,7 @@
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-calendar.glyphicon--right
-          = humanize_date(resource.created_at)
+          = humanize_date(resource.published_at)
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-user.glyphicon--right

--- a/app/views/shared/summary_cards/_list.html.slim
+++ b/app/views/shared/summary_cards/_list.html.slim
@@ -17,7 +17,7 @@
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-calendar.glyphicon--right
-          = humanize_date(resource.created_at)
+          = humanize_date(resource.published_at)
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-list.glyphicon--right

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -39,7 +39,7 @@
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-calendar.glyphicon--right
-          = humanize_date(resource.created_at)
+          = humanize_date(resource.published_at)
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-comment.glyphicon--right

--- a/db/migrate/20170217083000_add_published_at_to_resources.rb
+++ b/db/migrate/20170217083000_add_published_at_to_resources.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToResources < ActiveRecord::Migration[5.0]
+  def change
+    add_column :resources, :published_at, :timestamp
+  end
+end

--- a/db/migrate/20170217083004_add_published_at_to_groups.rb
+++ b/db/migrate/20170217083004_add_published_at_to_groups.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToGroups < ActiveRecord::Migration[5.0]
+  def change
+    add_column :groups, :published_at, :timestamp
+  end
+end

--- a/db/migrate/20170217083008_add_published_at_to_lists.rb
+++ b/db/migrate/20170217083008_add_published_at_to_lists.rb
@@ -1,0 +1,5 @@
+class AddPublishedAtToLists < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lists, :published_at, :timestamp
+  end
+end

--- a/spec/services/search_builders/sorter_spec.rb
+++ b/spec/services/search_builders/sorter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe SearchBuilders::Sorter do
         filter = SearchBuilders::Sorter.new('recent', es_params)
 
         expect(filter.build[:sort]).to eq([
-                                            { created_at: { order: :desc } },
+                                            { published_at: { order: :desc } },
                                             '_score'
                                           ])
       end
@@ -34,7 +34,7 @@ RSpec.describe SearchBuilders::Sorter do
         filter = SearchBuilders::Sorter.new('oldest', es_params)
 
         expect(filter.build[:sort]).to eq([
-                                            { created_at: { order: :asc } },
+                                            { published_at: { order: :asc } },
                                             '_score'
                                           ])
       end

--- a/spec/support/shared/indexable.rb
+++ b/spec/support/shared/indexable.rb
@@ -1,5 +1,44 @@
 RSpec.shared_examples 'indexable' do |name|
+  describe '#set_published_at' do
+    context 'when published_at already present' do
+      it 'does nothing' do
+        date = Time.now
+        record = create(name, published_at: date)
+        expect(record.published_at.utc.to_s).to eq date.utc.to_s
+      end
+    end
+
+    context 'when date in metadata' do
+      it 'set the published_at' do
+        date = Time.now
+        record = build(name)
+
+        if record.respond_to?(:metadata)
+          record.metadata = { date: date }
+          record.save!
+          expect(record.published_at.utc.to_s).to eq date.utc.to_s
+        end
+      end
+    end
+
+    context 'when date not in metadata' do
+      it 'set the published_at with created_at' do
+        record = create(name)
+        expect(record.published_at).to eq record.created_at
+      end
+    end
+  end
+
   describe 'Callbacks' do
+    describe 'after_create' do
+      it 'calls "set_published_at"' do
+        record = build(name)
+        allow(record).to receive(:set_published_at)
+        record.save
+        expect(record).to have_received(:set_published_at)
+      end
+    end
+
     describe 'after_commit on: [:create]' do
       it "adds the #{name} to the search index after creation" do
         allow(AddToIndexJob).to receive(:perform_async)


### PR DESCRIPTION
Related Issue: #123 

This pull request creates a shared date field named `published_at` for the `Group`, `Resource` and `List` models. This field is used to sort the records when searching through ElasticSearch. The value is defined when the record is created using either `metadata[date]` or `created_at`.