### PR TITLE
Add time stamping to user avatars

### DIFF
--- a/app/uploaders/avatar_uploader.rb
+++ b/app/uploaders/avatar_uploader.rb
@@ -29,6 +29,11 @@ class AvatarUploader < CarrierWave::Uploader::Base
   end
 
   def filename
-    "#{model.full_name.parameterize}-avatar" if original_filename
+    @name ||= "#{model.full_name.parameterize}-avatar-#{timestamp}" if original_filename
+  end
+
+  def timestamp
+    var = :"@#{mounted_as}_timestamp"
+    model.instance_variable_get(var) or model.instance_variable_set(var, Time.now.to_i)
   end
 end

--- a/spec/feature/user_updates_profile_spec.rb
+++ b/spec/feature/user_updates_profile_spec.rb
@@ -2,6 +2,9 @@ require 'rails_helper'
 
 RSpec.feature 'Update Profile' do
   scenario 'users can update their profile' do
+    fake_time = Time.now
+    allow(Time).to receive(:now).and_return(fake_time)
+
     user = feature_login
 
     click_link 'My Profile'
@@ -22,7 +25,7 @@ RSpec.feature 'Update Profile' do
     expect(user.last_name).to eq 'Wick'
     expect(user.email).to eq 'johnwick@example.com'
     expect(user.bio).to eq 'Something interesting.'
-    expect(user.avatar.url).to eq "/uploads/user/avatar/#{user.id}/john-wick-avatar"
+    expect(user.avatar.url).to eq "/uploads/user/avatar/#{user.id}/john-wick-avatar-#{fake_time.to_i}"
 
     expect(page).to have_selector("img[src='#{user.avatar.url}']")
   end


### PR DESCRIPTION
# Reason For Change

There is a bug right now where it looks like a user cannot update his profile picture. This is due to the way the avatar filename is saved - since there is no stamping, the browser is caching the picture and won't get the new one because they have the same name.

# Changes

- Change the `filename` method using [this](https://github.com/carrierwaveuploader/carrierwave/wiki/How-to:-Use-a-timestamp-in-file-names) as an example.