### PR TITLE
Link to Hypothesis when clicking on View Original Document

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -1,0 +1,5 @@
+module LinkHelper
+  def via_hypothesis(url)
+    "https://via.hypothes.is/#{url}"
+  end
+end

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -49,8 +49,9 @@
           span.glyphicon.glyphicon-edit.glyphicon--right
           = link_to '102 Annotations', '#'
       .summary-card__bottom-actions
-        .summary-card__metadata.summary-card__metadata--link
-          = link_to 'View Original Document', '#', class: 'btn btn-default'
+        - if resource.url
+          .summary-card__metadata.summary-card__metadata--link
+            = link_to 'View Original Document', via_hypothesis(resource.url), target: '_blank', class: 'btn btn-default'
         .summary-card__metadata.summary-card__metadata--link
           = link_to 'Read More', resource, class: 'btn btn-default'
       .clearfix

--- a/spec/feature/user_manages_resources_spec.rb
+++ b/spec/feature/user_manages_resources_spec.rb
@@ -10,6 +10,15 @@ RSpec.feature 'Managing resources' do
     expect(page).to have_text(resource.title)
   end
 
+  scenario 'users can access original document if URL is provided' do
+    user = feature_login
+    create(:resource, user: user, url: 'http://example.com')
+
+    click_link 'My Resources'
+    expect(find_link('View Original Document')[:href]).to eq('https://via.hypothes.is/http://example.com')
+    expect(find_link('View Original Document')[:target]).to eq('_blank')
+  end
+
   scenario 'users can view a resource' do
     user = feature_login
     resource = create(:resource, resource_type: :url, url: 'http://example.com', user: user)


### PR DESCRIPTION
[Trello Task](https://trello.com/c/QSOWiZbm/19-green-commons-link-the-view-original-to-a-hypothesis-via-link)

# Reason For Change

Until now, the "View Original Document" button present in the summary cards for resources wasn't pointing to anything. Now, if the resource has a URL, it will link to it through Hypothesis.

# Change

- Add `via_hypothesis` helper to build final URL.
- Update Resource summary card.
- Add a test to ensure the hypothesis URL is correctly generated.