### PR TITLE
Add Disqus To Resources and Groups pages

### DIFF
--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -109,4 +109,4 @@
             
   .row.page-details__row
     .col-lg-12
-      = render 'shared/components/discuss'
+      = render 'shared/integrations/disqus', entity: @group

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -109,4 +109,4 @@
             
   .row.page-details__row
     .col-lg-12
-      = render 'shared/integrations/disqus', entity: @group
+      = render 'shared/integrations/disqus/comments', entity: @group

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -13,3 +13,4 @@ html
       = render 'shared/alerts'
       = yield
     = yield :scripts
+    = render 'shared/integrations/disqus/script'

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -79,8 +79,8 @@
           | EXPORT
           span.glyphicon.glyphicon-cloud-download.glyphicon--left aria-hidden='true'
           
-  .row.page-details__row.hidden
+  .row.page-details__row
     .col-lg-12
-      = render 'shared/components/discuss'
+      = render 'shared/integrations/disqus', entity: @resource
 
   = render 'shared/components/explore', suggestions: @suggestions

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -81,6 +81,6 @@
           
   .row.page-details__row
     .col-lg-12
-      = render 'shared/integrations/disqus', entity: @resource
+      = render 'shared/integrations/disqus/comments', entity: @resource
 
   = render 'shared/components/explore', suggestions: @suggestions

--- a/app/views/shared/integrations/_disqus.html.slim
+++ b/app/views/shared/integrations/_disqus.html.slim
@@ -1,0 +1,18 @@
+#disqus_thread
+
+javascript:
+  var disqus_config = function () {
+    this.page.url = '#{request.original_url}';
+    this.page.identifier = '#{url_for(entity)}';
+  };
+
+  (function() {
+    var d = document, s = d.createElement('script');
+    s.src = '//green-commons.disqus.com/embed.js';
+    s.setAttribute('data-timestamp', +new Date());
+    (d.head || d.body).appendChild(s);
+  })();
+  
+noscript
+  | Please enable JavaScript to view the
+  a href="https://disqus.com/?ref_noscript"  comments powered by Disqus.

--- a/app/views/shared/integrations/disqus/_comments.html.slim
+++ b/app/views/shared/integrations/disqus/_comments.html.slim
@@ -1,4 +1,9 @@
-#disqus_thread
+.row.page-details__row--half
+  .col-lg-12
+    h3 DISCUSS
+.row
+  .col-lg-12
+    #disqus_thread
 
 javascript:
   var disqus_config = function () {

--- a/app/views/shared/integrations/disqus/_comments.html.slim
+++ b/app/views/shared/integrations/disqus/_comments.html.slim
@@ -9,6 +9,7 @@ javascript:
   var disqus_config = function () {
     this.page.url = '#{request.original_url}';
     this.page.identifier = '#{url_for(entity)}';
+    this.page.title = '#{entity.respond_to?(:title) ? entity.title : entity.name}';
   };
 
   (function() {

--- a/app/views/shared/integrations/disqus/_script.html.slim
+++ b/app/views/shared/integrations/disqus/_script.html.slim
@@ -1,0 +1,1 @@
+script#dsq-count-scr async="" src="//green-commons.disqus.com/count.js" 

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -21,6 +21,11 @@
           = humanize_date(resource.published_at)
       .summary-card__metadata
         p
+          span.glyphicon.glyphicon-comment.glyphicon--right
+          span.disqus-comment-count data-disqus-identifier="#{url_for(resource)}" 
+            | 0 Comments
+      .summary-card__metadata
+        p
           span.glyphicon.glyphicon-user.glyphicon--right
           | #{resource.users.count} members
       .summary-card__metadata
@@ -28,6 +33,6 @@
           span.glyphicon.glyphicon-list.glyphicon--right
           | #{resource.lists.count} Lists
       .summary-card__metadata.summary-card__metadata--right
-        = link_to 'Read More >>', resource
+        = link_to 'Read More', resource, class: 'btn btn-default'
       .clearfix
     

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -43,7 +43,8 @@
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-comment.glyphicon--right
-          | 13 Comments
+          span.disqus-comment-count data-disqus-identifier="#{url_for(resource)}" 
+            | 0 Comments
       .summary-card__metadata
         p
           span.glyphicon.glyphicon-edit.glyphicon--right


### PR DESCRIPTION
[Trello Task](https://trello.com/c/WQLZUjKt/20-green-commons-add-disqus-to-resource-group-pages)

This pull request adds the Disqus comments system to every resource and group pages. It also includes the comments count in the summary cards for these types of records.