### PR TITLE
Web API - You May Also Like

### DIFF
--- a/app/controllers/api/v1/search_controller.rb
+++ b/app/controllers/api/v1/search_controller.rb
@@ -10,7 +10,17 @@ module Api
           per: params[:per]
         )
 
-        render_json_api present_collection(search.results_with_relevancy, search.total_count)
+        results = search.results_with_relevancy
+        data = present_collection(results, search.total_count)
+
+        if results.any?
+          tags = results.map(&:cached_tags).flatten.compact.uniq
+          data[:related] = Suggesters::Tags.new(tags: tags,
+                                                except: results,
+                                                limit: 6).suggest
+        end
+
+        render_json_api data
       end
     end
   end

--- a/spec/support/api/schemas/jsonapi.json
+++ b/spec/support/api/schemas/jsonapi.json
@@ -50,7 +50,7 @@
           "$ref": "#/definitions/jsonapi"
         }
       },
-      "additionalProperties": false
+      "additionalProperties": true
     },
     "failure": {
       "type": "object",


### PR DESCRIPTION
[Trello Task](https://trello.com/c/sNh0NW8K/26-green-commons-search-api-you-may-also-like)

# Changes

This pull request adds the related entities to the search results JSON response. It adds them in the `related` key at the root level of the response. This kind of violates the JSON API specification but I didn't see where else to put them.