### PR TITLE
Web API - Field Picking

### DIFF
--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -11,7 +11,7 @@ module Api
                           current_url: request.original_url,
                           resource: resource,
                           total: total,
-                          params: query_params,
+                          params: params.to_unsafe_hash,
                           presenters_module: "::#{version}".constantize).as_json_api
     end
 
@@ -19,7 +19,7 @@ module Api
       Yumi::Presenter.new(url: base_url,
                           current_url: request.original_url,
                           resource: resource,
-                          params: query_params,
+                          params: params.to_unsafe_hash,
                           presenters_module: "::#{version}".constantize).as_json_api
     end
 
@@ -28,10 +28,6 @@ module Api
     end
 
     private
-
-    def query_params
-      params.permit(:q, :filters, :sort, :include, :page, :per)&.to_unsafe_hash
-    end
 
     def version
       self.class.name.split('::')[1]

--- a/lib/yumi/base.rb
+++ b/lib/yumi/base.rb
@@ -6,11 +6,12 @@ module Yumi
     extend Yumi::ClassMethods
 
     attr_accessor :url, :resource, :type, :links, :attributes, :relationships,
-                  :presenter_module, :prefix, :relationships
+                  :presenter_module, :prefix, :relationships, :fields
 
-    def initialize(url, resource, presenter_module = nil, prefix = nil)
+    def initialize(url, resource, presenter_module = nil, prefix = nil, fields = nil)
       @url = url
       @resource = resource
+      @fields = fields
       @presenter_module = presenter_module
       @prefix = prefix
       set_instance_variables

--- a/lib/yumi/presenter.rb
+++ b/lib/yumi/presenter.rb
@@ -1,12 +1,12 @@
 module Yumi
   class Presenter
-    def initialize(url:, current_url:, resource:, params: {}, total: nil,
-                   presenters_module: nil, meta: {})
+    def initialize(url:, current_url:, resource:, params: {},
+                   total: nil, presenters_module: nil, meta: {})
       @url = url
       @current_url = current_url
       @resource = resource
-      @params = params.slice(:q, :filters, :sort, :page, :per)
-      @includes = params[:include]&.split(',') || []
+      @params = params.slice(:q, :filters, :sort, :page, :per, :include, :fields)
+      @includes = @params[:include]&.split(',') || []
       @total = total
       @presenters_module = presenters_module
       @meta = meta
@@ -55,6 +55,7 @@ module Yumi
     def presenter_for(resource)
       Yumi::Utils::PresenterHelper.new(url: @url,
                                        resource: resource,
+                                       fields: @params[:fields],
                                        presenter_module: @presenters_module).presenter
     end
 

--- a/lib/yumi/presenters/attributes.rb
+++ b/lib/yumi/presenters/attributes.rb
@@ -8,9 +8,19 @@ module Yumi
       end
 
       def to_json_api
-        @presenter.attributes.each_with_object({}) do |attr, hash|
+        fields.each_with_object({}) do |attr, hash|
           hash[attr] = (@presenter.respond_to?(attr) ? @presenter : @resource).send(attr)
         end
+      end
+
+      private
+
+      def fields
+        return @presenter.attributes unless @presenter.fields
+        return @presenter.attributes unless @presenter.fields[@presenter.type.pluralize]
+
+        model_fields = @presenter.fields[@presenter.type.pluralize].split(',').map(&:to_sym)
+        model_fields.any? ? (@presenter.attributes & model_fields) : @presenter.attributes
       end
     end
   end

--- a/lib/yumi/utils/presenter_helper.rb
+++ b/lib/yumi/utils/presenter_helper.rb
@@ -1,9 +1,10 @@
 module Yumi
   module Utils
     class PresenterHelper
-      def initialize(url:, resource:, presenter_module: nil, prefix: nil)
+      def initialize(url:, resource:, fields: nil, presenter_module: nil, prefix: nil)
         @url = url
         @resource = resource
+        @fields = fields
         @presenter_module = presenter_module
         @prefix = prefix
       end
@@ -21,7 +22,7 @@ module Yumi
       private
 
       def presenter_instance
-        presenter_class.constantize.new(@url, @resource, @presenter_module, @prefix)
+        presenter_class.constantize.new(@url, @resource, @presenter_module, @prefix, @fields)
       end
 
       def presenter_class

--- a/spec/lib/yumi/presenter_spec.rb
+++ b/spec/lib/yumi/presenter_spec.rb
@@ -110,8 +110,8 @@ describe Yumi::Presenter do
 
       it 'correctly generates the links section' do
         expect(presenter_with_resources.as_json_api[:links]).to eq(
-          self: 'http://example.org:80/api/v1/games?page=1&per=10',
-          first: 'http://example.org:80/api/v1/games?page=1&per=10'
+          self: 'http://example.org:80/api/v1/games?include=levels,characters&page=1&per=10',
+          first: 'http://example.org:80/api/v1/games?include=levels,characters&page=1&per=10'
         )
       end
 
@@ -131,7 +131,7 @@ describe Yumi::Presenter do
 
       it 'correctly generates the links section' do
         expect(presenter_with_resource.as_json_api[:links]).to eq(
-          self: 'http://example.org:80/api/v1/games/1'
+          self: 'http://example.org:80/api/v1/games/1?include=levels,characters'
         )
       end
 

--- a/spec/lib/yumi/presenters/attributes_spec.rb
+++ b/spec/lib/yumi/presenters/attributes_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 describe Yumi::Presenters::Attributes do
   let(:attributes) { [:description, :slug] }
   let(:resource) { double(:_resource, description: "I'm a resource.", slug: 'whatever') }
-  let(:presenter) { double(:_presenter, resource: resource, attributes: attributes) }
+  let(:presenter) { double(:_presenter, resource: resource, attributes: attributes, fields: nil) }
 
   let(:klass) { Yumi::Presenters::Attributes.new(presenter) }
 
@@ -20,12 +20,27 @@ describe Yumi::Presenters::Attributes do
       let(:presenter) do
         double(:_presenter, resource: resource,
                             attributes: attributes,
+                            fields: nil,
                             description: "I'm a presenter.")
       end
 
       it 'outputs the hash with the description overridden' do
         expect(klass.to_json_api).to eq(description: "I'm a presenter.",
                                         slug: 'whatever')
+      end
+    end
+
+    context 'with fields picking' do
+      let(:presenter) do
+        double(:_presenter, resource: resource,
+                            attributes: attributes,
+                            type: 'resource',
+                            fields: { 'resources' => 'slug' },
+                            description: "I'm a presenter.")
+      end
+
+      it 'outputs the hash with only the slug' do
+        expect(klass.to_json_api).to eq(slug: 'whatever')
       end
     end
   end

--- a/spec/requests/api/v1/search_controller_spec.rb
+++ b/spec/requests/api/v1/search_controller_spec.rb
@@ -111,5 +111,14 @@ RSpec.describe Api::V1::SearchController, type: :request do
         end
       end
     end
+
+    describe 'field picking', :worker, :elasticsearch do
+      it 'only returns the name for groups' do
+        get '/api/v1/search?q=Group&fields[groups]=name'
+
+        expect(json_body['data'][0]['type']).to eq 'groups'
+        expect(json_body['data'][0]['attributes'].keys).to eq ['name']
+      end
+    end
   end
 end


### PR DESCRIPTION
[Trello Task](https://trello.com/c/c6omCM8R/41-green-commons-search-api-field-picking)

Merge after [this PR](https://github.com/greencommons/commons/pull/151) (and after switching the base branch).

# Changes

This pull request gives the option to users to select which fields they want to get from the Search resource as defined in the [JSON API Specification](http://jsonapi.org/format/#fetching-sparse-fieldsets).

Example: 

```
GET https://localhost:3000/api/v1/search?q=term&fields[groups]=name,long_description
```