### PR TITLE
New design for groups pages

### DIFF
--- a/app/assets/javascripts/components/autocomplete_form.js.jsx
+++ b/app/assets/javascripts/components/autocomplete_form.js.jsx
@@ -73,7 +73,7 @@ var AutocompleteForm = React.createClass({
 
   renderSubmit: function() {
     return (
-      <button id='add-member-button' name="button" type="submit" className="form-control btn btn-primary">
+      <button id='add-member-button' name="button" type="submit" className="form-control btn btn-dark-blue">
         <span aria-hidden="true" className="glyphicon glyphicon-plus"></span>
       </button>
     )

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -32,6 +32,7 @@
 @import "components/top-page-form";
 @import "components/filters";
 @import "components/sidelist";
+@import "components/user-picture";
 
 @import "pages/default";
 @import "pages/resource";

--- a/app/assets/stylesheets/components/_autocomplete.scss
+++ b/app/assets/stylesheets/components/_autocomplete.scss
@@ -17,10 +17,8 @@
   }
 
   &__suggestion {
-    background: inherit;
-    border-color: $autocomplete-border-color;
-    border-style: solid;
-    border-width: 0 1px;
+    background: $creme;
+    border: none;
     display: block;
     font-size: 14px;
     font-weight: normal;

--- a/app/assets/stylesheets/components/_form-box.scss
+++ b/app/assets/stylesheets/components/_form-box.scss
@@ -3,6 +3,8 @@
   @include box-shadow(2px 2px 4px rgba(0,0,0,.1));
   border-radius: 6px;
   background-color: #fff;
+  margin-top: 100px;
+  margin-bottom: 100px;
 
   &--middle {
     margin-top: 200px;

--- a/app/assets/stylesheets/components/_sidelist.scss
+++ b/app/assets/stylesheets/components/_sidelist.scss
@@ -11,6 +11,12 @@
       width: 100%;
       border-bottom: 1px solid $gc-clear-blue;
       padding: 6px 0;
+      font-size: 14px;
+      color: $gc-gray;
+
+      &:hover {
+        color: $gc-dark-gray;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/components/_top-page-form.scss
+++ b/app/assets/stylesheets/components/_top-page-form.scss
@@ -1,3 +1,3 @@
 .top-page-form {
-  margin-top: 36px;
+  margin-top: 22px;
 }

--- a/app/assets/stylesheets/components/_user-picture.scss
+++ b/app/assets/stylesheets/components/_user-picture.scss
@@ -1,0 +1,16 @@
+.user-picture {
+  &__image {
+    height: 36px;
+    border: 1px solid #fff;
+    border-radius: 25px;
+    position: relative;
+    margin-top: -6px;
+    display: inline-block;
+    float: left;
+
+  }
+
+  &__image--over {
+    margin-left: -18px;
+  }
+}

--- a/app/assets/stylesheets/helpers/_buttons.scss
+++ b/app/assets/stylesheets/helpers/_buttons.scss
@@ -16,57 +16,90 @@
 .btn--large {
   padding: 12px 30px;
   font-size: 16px;
+  font-weight: normal;
 }
 
-.btn-gc {
-  color: #FFFFFF;
-  background-color: #EF5350;
-  border-color: #EF5350;
-  text-transform: none;
-  font-weight: bold;
-  border-radius: 6px;
-  @include box-shadow(none);
+.btn--picture-cover {
+  border-radius: 25px;
+  height: 36px;
+  width: 36px;
+  background-color: $gc-dark-blue;
+  border: 1px solid #fff;
+  color: #fff;
+  padding: 6px 0;
+  margin-top: -6px;
+  margin-left: -18px;
 }
 
-.btn-gc:hover,
-.btn-gc:focus,
-.btn-gc:active,
-.btn-gc.active,
-.open .dropdown-toggle.btn-gc {
-  color: #FFFFFF;
-  background-color: #D64946;
-  border-color: #EF5350;
+.btn--picture-cover:hover,
+.btn--picture-cover:focus,
+.btn--picture-cover:active {
+  background-color: #425762;
+  color: #fff;
 }
 
-.btn-gc:active,
-.btn-gc.active,
-.open .dropdown-toggle.btn-gc {
-  background-image: none;
+@mixin gc-button($name, $color, $dark) {
+  .btn-#{$name} {
+    color: #FFFFFF;
+    background-color: $color;
+    border-color: $color;
+    text-transform: none;
+    font-weight: normal;
+    border-radius: 6px;
+    @include box-shadow(none);
+  }
+
+  .btn-#{$name}:hover,
+  .btn-#{$name}:focus,
+  .btn-#{$name}:active,
+  .btn-#{$name}.active,
+  .open .dropdown-toggle.btn-#{$name} {
+    color: #FFFFFF;
+    background-color: $dark;
+    border-color: $dark;
+  }
+
+  .btn-#{$name}:active,
+  .btn-#{$name}.active,
+  .open .dropdown-toggle.btn-#{$name} {
+    background-image: none;
+  }
+
+  .btn-#{$name}.disabled,
+  .btn-#{$name}[disabled],
+  fieldset[disabled] .btn-#{$name},
+  .btn-#{$name}.disabled:hover,
+  .btn-#{$name}[disabled]:hover,
+  fieldset[disabled] .btn-#{$name}:hover,
+  .btn-#{$name}.disabled:focus,
+  .btn-#{$name}[disabled]:focus,
+  fieldset[disabled] .btn-#{$name}:focus,
+  .btn-#{$name}.disabled:active,
+  .btn-#{$name}[disabled]:active,
+  fieldset[disabled] .btn-#{$name}:active,
+  .btn-#{$name}.disabled.active,
+  .btn-#{$name}[disabled].active,
+  fieldset[disabled] .btn-#{$name}.active {
+    background-color: #EF5350;
+    border-color: #EF5350;
+  }
+
+  .btn-#{$name} .badge {
+    color: #EF5350;
+    background-color: #FFFFFF;
+  }
 }
 
-.btn-gc.disabled,
-.btn-gc[disabled],
-fieldset[disabled] .btn-gc,
-.btn-gc.disabled:hover,
-.btn-gc[disabled]:hover,
-fieldset[disabled] .btn-gc:hover,
-.btn-gc.disabled:focus,
-.btn-gc[disabled]:focus,
-fieldset[disabled] .btn-gc:focus,
-.btn-gc.disabled:active,
-.btn-gc[disabled]:active,
-fieldset[disabled] .btn-gc:active,
-.btn-gc.disabled.active,
-.btn-gc[disabled].active,
-fieldset[disabled] .btn-gc.active {
-  background-color: #EF5350;
-  border-color: #EF5350;
-}
+@include gc-button('gc', #EF5350, #D64946);
+@include gc-button('dark-blue', $gc-dark-blue, #425762);
 
-.btn-gc .badge {
-  color: #EF5350;
-  background-color: #FFFFFF;
-}
+@include gc-button('book', $books-dark, $books-darker);
+@include gc-button('article', $articles-dark, $articles-darker);
+@include gc-button('report', $reports-dark, $reports-darker);
+@include gc-button('url', $urls-dark, $urls-darker);
+
+@include gc-button('groups', $groups-dark, $groups-darker);
+@include gc-button('lists', $lists-dark, $lists-darker);
 
 // White button
 .btn-white {
@@ -75,7 +108,7 @@ fieldset[disabled] .btn-gc.active {
   border: 1px solid $gray-lighter;
   @include box-shadow(none);
   text-transform: none;
-  font-weight: bold;
+  font-weight: normal;
 }
 
 .btn-white:hover,
@@ -112,252 +145,6 @@ fieldset[disabled] .btn-white.active {
 }
 
 .btn-white .badge {
-  color: #EF5350;
-  background-color: #FFFFFF;
-}
-
-// Dark blue button
-.btn-dark-blue {
-  color: #FFF;
-  background-color: $gc-dark-blue;
-  border-color: $gc-dark-blue;
-  text-transform: none;
-  font-weight: bold;
-  @include box-shadow(none);
-}
-
-.btn-dark-blue:hover,
-.btn-dark-blue:focus,
-.btn-dark-blue:active,
-.btn-dark-blue.active,
-.open .dropdown-toggle.btn-dark-blue {
-  color: #FFFFFF;
-  background-color: #425762;
-  border-color: #EF5350;
-}
-
-.btn-dark-blue:active,
-.btn-dark-blue.active,
-.open .dropdown-toggle.btn-dark-blue {
-  background-image: none;
-}
-
-.btn-dark-blue.disabled,
-.btn-dark-blue[disabled],
-fieldset[disabled] .btn-dark-blue,
-.btn-dark-blue.disabled:hover,
-.btn-dark-blue[disabled]:hover,
-fieldset[disabled] .btn-dark-blue:hover,
-.btn-dark-blue.disabled:focus,
-.btn-dark-blue[disabled]:focus,
-fieldset[disabled] .btn-dark-blue:focus,
-.btn-dark-blue.disabled:active,
-.btn-dark-blue[disabled]:active,
-fieldset[disabled] .btn-dark-blue:active,
-.btn-dark-blue.disabled.active,
-.btn-dark-blue[disabled].active,
-fieldset[disabled] .btn-dark-blue.active {
-  background-color: #EF5350;
-  border-color: #EF5350;
-}
-
-.btn-dark-blue .badge {
-  color: #EF5350;
-  background-color: #FFFFFF;
-}
-
-.btn-book {
-  color: #FFF;
-  background-color: $books-dark;
-  border-color: $books-dark;
-  text-transform: none;
-  font-weight: bold;
-  @include box-shadow(none);
-}
-
-.btn-book:hover,
-.btn-book:focus,
-.btn-book:active,
-.btn-book.active,
-.open .dropdown-toggle.btn-book {
-  color: #FFFFFF;
-  background-color: $books-light;
-  border-color: $books-light;
-}
-
-.btn-book:active,
-.btn-book.active,
-.open .dropdown-toggle.btn-book {
-  background-image: none;
-}
-
-.btn-book.disabled,
-.btn-book[disabled],
-fieldset[disabled] .btn-book,
-.btn-book.disabled:hover,
-.btn-book[disabled]:hover,
-fieldset[disabled] .btn-book:hover,
-.btn-book.disabled:focus,
-.btn-book[disabled]:focus,
-fieldset[disabled] .btn-book:focus,
-.btn-book.disabled:active,
-.btn-book[disabled]:active,
-fieldset[disabled] .btn-book:active,
-.btn-book.disabled.active,
-.btn-book[disabled].active,
-fieldset[disabled] .btn-book.active {
-  background-color: #EF5350;
-  border-color: #EF5350;
-}
-
-.btn-book .badge {
-  color: #EF5350;
-  background-color: #FFFFFF;
-}
-
-.btn-article {
-  color: #FFF;
-  background-color: $articles-dark;
-  border-color: $articles-dark;
-  text-transform: none;
-  font-weight: bold;
-  @include box-shadow(none);
-}
-
-.btn-article:hover,
-.btn-article:focus,
-.btn-article:active,
-.btn-article.active,
-.open .dropdown-toggle.btn-article {
-  color: #FFFFFF;
-  background-color: $articles-darker;
-  border-color: $articles-darker;
-}
-
-.btn-article:active,
-.btn-article.active,
-.open .dropdown-toggle.btn-article {
-  background-image: none;
-}
-
-.btn-article.disabled,
-.btn-article[disabled],
-fieldset[disabled] .btn-article,
-.btn-article.disabled:hover,
-.btn-article[disabled]:hover,
-fieldset[disabled] .btn-article:hover,
-.btn-article.disabled:focus,
-.btn-article[disabled]:focus,
-fieldset[disabled] .btn-article:focus,
-.btn-article.disabled:active,
-.btn-article[disabled]:active,
-fieldset[disabled] .btn-article:active,
-.btn-article.disabled.active,
-.btn-article[disabled].active,
-fieldset[disabled] .btn-article.active {
-  background-color: #EF5350;
-  border-color: #EF5350;
-}
-
-.btn-article .badge {
-  color: #EF5350;
-  background-color: #FFFFFF;
-}
-
-.btn-report {
-  color: #FFF;
-  background-color: $reports-dark;
-  border-color: $reports-dark;
-  text-transform: none;
-  font-weight: bold;
-  @include box-shadow(none);
-}
-
-.btn-report:hover,
-.btn-report:focus,
-.btn-report:active,
-.btn-report.active,
-.open .dropdown-toggle.btn-report {
-  color: #FFFFFF;
-  background-color: $reports-darker;
-  border-color: $reports-darker;
-}
-
-.btn-report:active,
-.btn-report.active,
-.open .dropdown-toggle.btn-report {
-  background-image: none;
-}
-
-.btn-report.disabled,
-.btn-report[disabled],
-fieldset[disabled] .btn-report,
-.btn-report.disabled:hover,
-.btn-report[disabled]:hover,
-fieldset[disabled] .btn-report:hover,
-.btn-report.disabled:focus,
-.btn-report[disabled]:focus,
-fieldset[disabled] .btn-report:focus,
-.btn-report.disabled:active,
-.btn-report[disabled]:active,
-fieldset[disabled] .btn-report:active,
-.btn-report.disabled.active,
-.btn-report[disabled].active,
-fieldset[disabled] .btn-report.active {
-  background-color: #EF5350;
-  border-color: #EF5350;
-}
-
-.btn-report .badge {
-  color: #EF5350;
-  background-color: #FFFFFF;
-}
-
-.btn-url {
-  color: #FFF;
-  background-color: $urls-dark;
-  border-color: $urls-dark;
-  text-transform: none;
-  font-weight: bold;
-  @include box-shadow(none);
-}
-
-.btn-url:hover,
-.btn-url:focus,
-.btn-url:active,
-.btn-url.active,
-.open .dropdown-toggle.btn-url {
-  color: #FFFFFF;
-  background-color: $urls-darker;
-  border-color: $urls-darker;
-}
-
-.btn-url:active,
-.btn-url.active,
-.open .dropdown-toggle.btn-url {
-  background-image: none;
-}
-
-.btn-url.disabled,
-.btn-url[disabled],
-fieldset[disabled] .btn-url,
-.btn-url.disabled:hover,
-.btn-url[disabled]:hover,
-fieldset[disabled] .btn-url:hover,
-.btn-url.disabled:focus,
-.btn-url[disabled]:focus,
-fieldset[disabled] .btn-url:focus,
-.btn-url.disabled:active,
-.btn-url[disabled]:active,
-fieldset[disabled] .btn-url:active,
-.btn-url.disabled.active,
-.btn-url[disabled].active,
-fieldset[disabled] .btn-url.active {
-  background-color: #EF5350;
-  border-color: #EF5350;
-}
-
-.btn-url .badge {
   color: #EF5350;
   background-color: #FFFFFF;
 }

--- a/app/assets/stylesheets/helpers/_buttons.scss
+++ b/app/assets/stylesheets/helpers/_buttons.scss
@@ -109,6 +109,7 @@
   @include box-shadow(none);
   text-transform: none;
   font-weight: normal;
+  border-radius: 6px;
 }
 
 .btn-white:hover,
@@ -147,4 +148,27 @@ fieldset[disabled] .btn-white.active {
 .btn-white .badge {
   color: #EF5350;
   background-color: #FFFFFF;
+}
+
+.btn-white-transparent {
+  color: $gc-dark-gray;
+  background-color: none;
+  border: 1px solid $gc-clear-blue;
+  @include box-shadow(none);
+  text-transform: none;
+  font-weight: normal;
+  font-size: 16px;
+  border-radius: 6px;
+
+  i {
+    color: $gc-clear-blue;
+  }
+}
+
+.btn-white-transparent:hover,
+.btn-white-transparent:focus,
+.btn-white-transparent:active,
+.btn-white-transparent.active,
+.open .dropdown-toggle.btn-white-transparent {
+  background-color: $gray-lighter;
 }

--- a/app/assets/stylesheets/pages/_default.scss
+++ b/app/assets/stylesheets/pages/_default.scss
@@ -67,6 +67,10 @@
     }
   }
 
+  &__metadata--half-margin {
+    margin-right: 10px;
+  }
+
   &__description {
     font-size: 17px;
     line-height: 31px;

--- a/app/assets/stylesheets/pages/_resource.scss
+++ b/app/assets/stylesheets/pages/_resource.scss
@@ -21,6 +21,10 @@
     background-color: $urls-light;
   }
 
+  &__background--groups {
+    background-color: $groups-light;
+  }
+
   &__container {
     background-color: $creme;
   }

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -3,7 +3,7 @@ class GroupsController < ApplicationController
   before_action :set_group, only: [:show, :edit, :update, :destroy, :leave]
 
   def index
-    @groups = policy_scope(Group)
+    @groups = policy_scope(Group).page(params[:page] || 1).per(10)
   end
 
   def show

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -30,6 +30,7 @@ class GroupsController < ApplicationController
     authorize @group
 
     if @group.save
+      @group.touch
       @group.add_admin(current_user)
       redirect_to @group, notice: 'Group was successfully created.'
     else
@@ -39,6 +40,7 @@ class GroupsController < ApplicationController
 
   def update
     if @group.update(group_params)
+      @group.touch
       redirect_to @group, notice: 'Group was successfully updated.'
     else
       render :edit
@@ -58,6 +60,7 @@ class GroupsController < ApplicationController
   end
 
   def group_params
-    params.require(:group).permit(:name, :short_description, :long_description, :tag_list, :url, :email)
+    params.require(:group).permit(:name, :short_description, :long_description,
+                                  :tag_list, :url, :email)
   end
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,6 +8,11 @@ class GroupsController < ApplicationController
 
   def show
     @resources = @group.latest_resources
+    @lists = @group.lists
+    @similar = Suggesters::Tags.new(tags: @group.cached_tags,
+                                    except: @group,
+                                    limit: 12,
+                                    models: [Group]).suggest
     @group_current_user = @group.find_member(current_user)
     @admin = @group_current_user.try(:admin?)
   end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -58,6 +58,6 @@ class GroupsController < ApplicationController
   end
 
   def group_params
-    params.require(:group).permit(:name, :short_description, :long_description, :url, :email)
+    params.require(:group).permit(:name, :short_description, :long_description, :tag_list, :url, :email)
   end
 end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -4,10 +4,6 @@ module Taggable
   included do
     acts_as_taggable
 
-    before_save do
-      self.cached_tags = tag_list
-    end
-
     after_touch do
       update(cached_tags: tag_list)
     end

--- a/app/models/concerns/taggable.rb
+++ b/app/models/concerns/taggable.rb
@@ -4,6 +4,10 @@ module Taggable
   included do
     acts_as_taggable
 
+    before_save do
+      self.cached_tags = tag_list
+    end
+
     after_touch do
       update(cached_tags: tag_list)
     end

--- a/app/models/groups_user.rb
+++ b/app/models/groups_user.rb
@@ -6,4 +6,6 @@ class GroupsUser < ApplicationRecord
   validates :user, presence: true
   validates :admin, inclusion: { in: [true, false] }
   validates :user_id, uniqueness: { scope: :group_id }
+
+  scope :sorted, -> { order(:created_at) }
 end

--- a/app/views/groups/_form.html.slim
+++ b/app/views/groups/_form.html.slim
@@ -1,39 +1,35 @@
 .row
-  .col-lg-8
-    .bs-component
-      = form_for(group, html: { class: "form-horizontal" }) do |f|
-        - if group.errors.any?
-          .alert.alert-warning role="alert"
+  .col-xs-12.col-md-8.col-md-offset-2
+    = form_for(group) do |f|
+      = render 'shared/alerts'
+      - if group.errors.any?
+        .page-details__row
+          .alert.alert-warning role='alert'
             p 
-              = pluralize(group.errors.count, "error")
+              = pluralize(group.errors.count, 'error')
               |  prohibited this group from being saved.
             ul
               - group.errors.full_messages.each do |message|
                 li= message
-        fieldset
-          .form-group
-            = f.label :name, "NAME", class: "col-lg-2 control-label"
-            .col-lg-10
-              = f.text_field :name, class: "form-control", placeholder: "Group Name"
-          .form-group
-            = f.label :short_description, "ABOUT (Short)", class: "col-lg-2 control-label"
-            .col-lg-10
-              = f.text_field :short_description, class: "form-control"
-              span.help-block Tweet Version (140 characters max)
-          .form-group
-            = f.label :long_description, "ABOUT (Long)", class: "col-lg-2 control-label"
-            .col-lg-10
-              = f.text_area :long_description, class: "form-control"
-          .form-group
-            = f.label :url, "URL", class: "col-lg-2 control-label"
-            .col-lg-10
-              = f.text_field :url, class: "form-control"
-          .form-group
-            = f.label :email, "EMAIL", class: "col-lg-2 control-label"
-            .col-lg-10
-              = f.text_field :email, class: "form-control"
-          .form-group
-            .col-lg-4.col-lg-offset-2
-              = f.submit submit_label, class: "form-control btn btn-primary"
-            .col-lg-4
-              = link_to "Back", cancel, class: "btn btn-default form-control"
+      fieldset
+        .form-group
+          = f.label :name, 'Name', class: 'control-label'
+          = f.text_field :name, class: 'form-control', placeholder: 'Group Name...'
+        .form-group
+          = f.label :short_description, 'About (short)', class: 'control-label'
+          = f.text_field :short_description, class: 'form-control', placeholder: 'Tweet Version (140 characters max)'
+        .form-group
+          = f.label :long_description, 'About (long)', class: 'control-label'
+          = f.text_area :long_description, class: 'form-control'
+        .form-group
+          = f.label :tag_list, 'Tags', class: 'control-label'
+          = f.text_field :tag_list, value: @group.cached_tags.join(', '), class: 'form-control', placeholder: 'Separate tags with commas...'
+        .form-group
+          = f.label :url, 'URL', class: 'control-label'
+          = f.text_field :url, class: 'form-control', placeholder: 'URL...'
+        .form-group
+          = f.label :email, 'Email', class: 'control-label'
+          = f.text_field :email, class: 'form-control', placeholder: 'Email...'
+        .form-group
+          .pull-right
+            = f.submit submit_label, class: 'form-control btn btn-gc'

--- a/app/views/groups/edit.html.slim
+++ b/app/views/groups/edit.html.slim
@@ -1,4 +1,11 @@
-.row
-  .col-lg-12 
-    h1 Edit #{@group.name}
-    = render 'form', group: @group, submit_label: 'UPDATE', cancel: @group
+.page-details--creme-bg
+  .container
+    .row
+      .col-xs-12.col-md-8.col-md-offset-2
+        .form-box
+          .form-box__title
+            .row
+              .col-xs-12.col-md-8.col-md-offset-2
+                h1 Edit #{@group.name}
+          .form-box__body
+            = render 'form', group: @group, submit_label: 'Update', cancel: @group

--- a/app/views/groups/index.html.slim
+++ b/app/views/groups/index.html.slim
@@ -1,8 +1,14 @@
-.row
-  .col-lg-12
-    h1 My Groups
-    - @groups.each_slice(2) do |slice|
-      .row 
-        - slice.each do |group|
-          .col-xs-12.col-md-6
-            = render "shared/summary_cards/main", resource: group
+.page-details.page-details--creme-bg
+  .container
+    .row
+      .col-xs-12
+        h1 My Groups
+        - @groups.each_slice(2) do |slice|
+          .row 
+            - slice.each do |group|
+              .col-xs-12.col-md-6
+                = render "shared/summary_cards/main", resource: group
+                
+    .row.page-details__row
+      .col-xs-12.text-center
+        = paginate @groups

--- a/app/views/groups/new.html.slim
+++ b/app/views/groups/new.html.slim
@@ -1,4 +1,11 @@
-.row
-  .col-lg-12 
-    h1 Create Group
-    = render 'form', group: @group, submit_label: 'CREATE', cancel: groups_path
+.page-details--creme-bg
+  .container
+    .row
+      .col-xs-12.col-md-8.col-md-offset-2
+        .form-box
+          .form-box__title
+            .row
+              .col-xs-12.col-md-8.col-md-offset-2
+                h1 Create Group
+          .form-box__body
+            = render 'form', group: @group, submit_label: 'Create', cancel: @group

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -1,3 +1,81 @@
+.page-details.resource-page 
+  div class="resource-page__background resource-page__background--groups"
+    = render 'shared/alerts'
+  .resource-page__container
+    .container
+      .row
+        .col-xs-12
+          .resource-page__wrapper
+            .resource-page__header
+              .row
+                .page-details__row--more-space 
+                  .col-xs-12.col-sm-6.col-md-4
+                    div class="entity-icon entity-icon--big entity-icon--groups"
+                      i class="fa fa-users"
+                    div class="resource-page__type resource-page__type--groups"
+                      | Groups
+                  .col-xs-12.col-sm-6.col-md-8
+                    .resource-actions.resource-actions--align-middle
+                      - if policy(@group).edit?
+                        = link_to edit_group_path(@group), class: 'resource-actions__button btn btn-white resource-actions__button--right' do
+                          | Settings
+                          i.fa.fa-cog.glyphicon--left
+                      - if @current_user                                        
+                        - if @group_current_user                                 
+                          = link_to leave_group_members_path(@group), method: :delete, 
+                                    data: { confirm: 'Are you sure you want to leave this group?' },
+                                    class: 'resource-actions__button btn btn-dark-blue' do
+                            | Leave group
+                            i.fa.fa-user-times.glyphicon--left
+                        - else
+                          = link_to join_group_members_path(@group), method: :post, 
+                                    class: 'resource-actions__button btn btn-dark-blue' do
+                            | Join group
+                            i.fa.fa-user-plus.glyphicon--left
+                  .clearfix
+              .row
+                .page-details__row--half
+                  .col-xs-12
+                    h1.resource-page__title
+                      = @group.name
+                  .clearfix
+              .row
+                .page-details__row
+                  .col-xs-12
+                    .page-details__metadata.page-details__metadata--half-margin 
+                      .user-picture
+                        = image_tag(@group.users[0] ? @group.users[0].avatar_url : 'user.png', 
+                                    class: 'user-picture__image')
+                        = image_tag(@group.users[1] ? @group.users[1].avatar_url : 'user.png', 
+                                    class: 'user-picture__image user-picture__image--over')
+                        = link_to group_members_path(@group), class: 'btn btn--picture-cover' do
+                          = @group.users.count
+                    .page-details__metadata 
+                      | members
+                    .page-details__metadata 
+                      i.fa.fa-calendar.glyphicon--right
+                      = "Published Date: #{humanize_date(@group.published_at)}"
+                  .clearfix
+              .row
+                .page-details__row
+                  .col-xs-12
+                    p.page-details__description
+                      = @group.long_description
+                  .clearfix
+                  
+              .row
+                .col-xs-12.col-md-6
+                  = react_component 'Tags', { authenticity_token: form_authenticity_token,
+                                              submit_url: group_tags_path(@group),
+                                              tags: @group.cached_tags,
+                                              can_create: policy(@group).update? }, { prerender: true }
+                .col-xs-12.col-md-6
+                  .resource-actions
+                    - if policy(@group).destroy?
+                      = link_to 'Delete', @group, method: 'DELETE', class: "btn btn-groups btn--margin-right btn--large", data: { confirm: 'Are you sure?' }   
+                    = link_to "Add to a list (#{@group.lists.count})", '#', class: "btn btn-groups btn--large"
+
+
 .page-details
   = render 'shared/alerts'
   .row.page-details__row
@@ -11,21 +89,9 @@
                                                 label: @group.lists.count,
                                                 classes: 'resource-actions__button--right',
                                                 style: 'primary'
-        - if @current_user                                        
-          - if @group_current_user                                 
-            = link_to 'LEAVE GROUP', leave_group_members_path(@group), 
-                                     method: :delete, 
-                                     data: { confirm: 'Are you sure you want to leave this group?' },
-                                     class: 'resource-actions__button--right btn btn-default'
-          - else
-            = link_to 'JOIN GROUP', join_group_members_path(@group), 
-                                    method: :post, 
-                                    class: 'resource-actions__button--right btn btn-default'
         = link_to group_members_path(@group), class: 'resource-actions__button--right btn btn-primary' do
           | MEMBERS 
           .badge #{@group.users.count}
-        = link_to 'SETTINGS', edit_group_path(@group), class: 'resource-actions__button btn btn-primary'
-
   .row.page-details__row.page-details__row--half
     .col-lg-1
       = image_tag 'user.png', class: 'page-details__picture'

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -76,104 +76,53 @@
                     = link_to "Add to a list (#{@group.lists.count})", '#', class: "btn btn-groups btn--large"
 
 
-.page-details
-  = render 'shared/alerts'
-  .row.page-details__row
-    .col-xs-2
-      = link_to '< BACK', groups_path, class: 'btn btn-default'
-      
-    .col-xs-10
-      .resource-actions
-        = render 'shared/components/btn_count', path: '#', 
-                                                text: 'ADD TO LIST', 
-                                                label: @group.lists.count,
-                                                classes: 'resource-actions__button--right',
-                                                style: 'primary'
-        = link_to group_members_path(@group), class: 'resource-actions__button--right btn btn-primary' do
-          | MEMBERS 
-          .badge #{@group.users.count}
-  .row.page-details__row.page-details__row--half
-    .col-lg-1
-      = image_tag 'user.png', class: 'page-details__picture'
-    .col-lg-11 
-      h1= @group.name
-      
-  .row.page-details__row
-    .col-lg-12
-      = react_component 'Tags', { authenticity_token: form_authenticity_token,
-                                  submit_url: group_tags_path(@group),
-                                  tags: @group.cached_tags,
-                                  can_create: @admin }, { prerender: true }
-            
-  .row
-    .col-lg-12
-      h3 ABOUT
-      p
-        = @group.short_description
-      #page-details__more.collapse
-        .row
-          .col-xs-12
-            p
-              span.glyphicon.glyphicon-text-color.glyphicon--right
-              = @group.long_description
-        .row
-          .col-xs-12
-            p
-              span.glyphicon.glyphicon-share.glyphicon--right
-              = link_to @group.url, @group.url
-        .row
-          .col-xs-12
-            p
-              span.glyphicon.glyphicon-envelope.glyphicon--right
-              = mail_to @group.email, @group.email
-        .row
-          .col-xs-12
-            p
-              span.glyphicon.glyphicon-calendar.glyphicon--right
-              = humanize_date(@group.created_at)
-        .row
-          .col-xs-12
-            p
-              span.glyphicon.glyphicon-edit.glyphicon--right
-              = humanize_date(@group.updated_at)      
-    
-  .row.page-details__row
-    .col-lg-12.text-right
-      = link_to '#', data: { expand: '#page-details__more', reverse: '#page-details__hide' },  id: 'page-details__show' do
-        | SEE MORE
-        span.glyphicon.glyphicon-menu-down.glyphicon--left aria-hidden='true'
-      = link_to '#', data: { expand: '#page-details__more', reverse: '#page-details__show' }, id: 'page-details__hide', class: 'collapse' do
-        | HIDE
-        span.glyphicon.glyphicon-menu-up.glyphicon--left aria-hidden='true'
-        
-  .row.page-details__row
-    .col-lg-12
-      .row
-        .col-lg-8
-          h3 WHAT'S NEW
-        .col-lg-4
-          .resource-actions
-            = link_to 'SEE ALL', '#', class: 'btn btn-primary resource-actions__button--align-title'
-      .row
-        - @resources.each do |resource|
-          .col-lg-12
-            = render 'shared/summary_cards/main', resource: resource
-                  
-  .row.page-details__row
-    .col-lg-12
-      .row.page-details__row--half
-        .col-lg-8
-          h3 LISTS
-        .col-lg-4
-          .resource-actions
-            = link_to 'NEW LIST', '#', class: 'btn btn-primary resource-actions__button--right resource-actions__button--align-title'
-            = link_to 'ALL LISTS', '#', class: 'btn btn-primary resource-actions__button--align-title'
-      - @group.lists.each_slice(2) do |slice|
-        .row
-          - slice.each do |list|
-            .col-lg-6
-              = render 'shared/summary_cards/main', resource: list
-            
-  .row.page-details__row
-    .col-lg-12
-      = render 'shared/integrations/disqus/comments', entity: @group
+            .resource-page__content
+              .row
+                .col-xs-12.col-md-9
+                  .row.page-details__row--double
+                    .col-xs-12
+                      .page-details__section-title.page-details__row
+                        h6.pull-left
+                          | What's new
+                        .pull-right
+                          = link_to '#', class: 'btn btn-white-transparent' do
+                            | See all
+                            i.fa.fa-long-arrow-right.glyphicon--left
+                        .clearfix
+                      - @resources.each do |resource|
+                        .row
+                          .col-lg-12
+                            = render 'shared/summary_cards/main', resource: resource
+                  .row.page-details__row--double
+                    .col-xs-12
+                      .page-details__section-title.page-details__row
+                        h6.pull-left
+                          | Lists
+                        .pull-right
+                          = link_to '#', class: 'btn btn-white-transparent resource-actions__button--right' do
+                            | New list
+                            i.fa.fa-plus.glyphicon--left
+                          = link_to '#', class: 'btn btn-white-transparent' do
+                            | See all
+                            i.fa.fa-long-arrow-right.glyphicon--left
+                          
+                        .clearfix
+                      - @lists.each do |list|
+                        .row
+                          .col-xs-12
+                            = render 'shared/summary_cards/main', resource: list
+                          
+                  .row
+                    .col-xs-12
+                      .page-details__row--double
+                        = render 'shared/integrations/disqus/comments', entity: @group
+                              
+                .col-xs-12.col-md-3
+                  .page-details__row--double
+                    .page-details__section-title
+                      h6
+                        | Similar groups
+                    ul.sidelist
+                      - @similar.each do |similar_group|
+                        li= link_to similar_group.name, group_path(similar_group)
+                    

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -1,23 +1,56 @@
-.row
-  .col-xs-2
-    = link_to '< BACK', @group, class: 'btn btn-default'
-.row
-  .col-xs-12.col-md-6.col-lg-6
-    h1 #{@group.name} Group
-    h4 #{@members.count} members
-  .col-xs-12.col-md-6.col-lg-6
-    - if @admin
-      .top-page-form
-        = react_component('AutocompleteForm', { name: 'user-autocomplete',
-                                                field: 'email',
-                                                action: group_members_path,
-                                                autocomplete_url: autocomplete_members_path(group_id: @group.id),
-                                                placeholder: 'Type member name or email',
-                                                authenticity_token: form_authenticity_token }, 
-                                              { prerender: true })
-
-- @members.each_slice(2) do |slice|
-  .row
-    - slice.each do |member|
-      .col-xs-12.col-lg-6
-        = render 'shared/summary_cards/main', resource: member
+.page-details.resource-page 
+  div class="resource-page__background resource-page__background--groups"
+    = render 'shared/alerts'
+  .resource-page__container
+    .container
+      .row
+        .col-xs-12
+          .resource-page__wrapper
+            .resource-page__header
+              .row
+                .page-details__row--more-space 
+                  .col-xs-12.col-sm-6.col-md-5
+                    div class="entity-icon entity-icon--big entity-icon--groups"
+                      i class="fa fa-users"
+                    div class="resource-page__type resource-page__type--groups"
+                      | Group Members
+                  .col-xs-12.col-sm-6.col-md-7
+                    - if @admin
+                      .top-page-form
+                        = react_component('AutocompleteForm', { name: 'user-autocomplete',
+                                                                field: 'email',
+                                                                action: group_members_path,
+                                                                autocomplete_url: autocomplete_members_path(group_id: @group.id),
+                                                                placeholder: 'Type member name or email',
+                                                                authenticity_token: form_authenticity_token }, 
+                                                              { prerender: true })
+                  .clearfix
+              .row
+                .page-details__row--half
+                  .col-xs-12
+                    h1.resource-page__title
+                      = link_to @group.name, @group
+                  .clearfix
+              .row
+                .page-details__row
+                  .col-xs-12
+                    .page-details__metadata.page-details__metadata--half-margin 
+                      .user-picture
+                        = image_tag(@group.users[0] ? @group.users[0].avatar_url : 'user.png', 
+                                    class: 'user-picture__image')
+                        = image_tag(@group.users[1] ? @group.users[1].avatar_url : 'user.png', 
+                                    class: 'user-picture__image user-picture__image--over')
+                        a class='btn btn--picture-cover'
+                          = @group.users.count
+                    .page-details__metadata 
+                      | members
+                    .page-details__metadata 
+                      i.fa.fa-calendar.glyphicon--right
+                      = "Published Date: #{humanize_date(@group.published_at)}"
+                  .clearfix
+              .page-details__row
+                - @members.sorted.each_slice(2) do |slice|
+                  .row
+                    - slice.each do |member|
+                      .col-xs-12.col-md-6
+                        = render 'shared/summary_cards/main', resource: member

--- a/app/views/shared/summary_cards/_member.html.slim
+++ b/app/views/shared/summary_cards/_member.html.slim
@@ -1,30 +1,30 @@
 .summary-card
   .summary-card__body
-    .summary-card__row.row
-      .col-xs-2
+    .summary-card__row
+      div class="entity-icon"
         = image_tag resource.user.avatar
-      .col-xs-10
-        .summary-card__row
-          .summary-card__more
-            = humanize_date(resource.created_at)
-          .summary-card__metadata
-            h5 
-              - if resource.user.full_name.present?
-                = resource.user.full_name
-                br
-                = resource.user.email
-              - else
-                = resource.user.email
-          .clearfix
-        .summary-card__row.summary-card__row
-          p
-            = resource.user.bio
-            
+      .summary-card__title
+        h5
+          - if resource.user.full_name.present?
+            = resource.user.full_name
+          - else
+            = resource.user.email
+        h6
+          - if resource.user.full_name.present?
+            = resource.user.email
+            |  &bull; 
+          = humanize_date(resource.created_at)
+      .clearfix
+    .summary-card__row
+      p
+        = resource.user.bio
+        
   - if resource.user != current_user && @admin
     .summary-card__actions
       - if resource.admin?
-        = link_to 'REMOVE ADMIN', remove_admin_group_member_path(@group, resource), method: :post
+        = link_to 'Remove admin rights', remove_admin_group_member_path(@group, resource), method: :post
       - else
-        = link_to 'MAKE ADMIN', make_admin_group_member_path(@group, resource), method: :post
+        = link_to 'Make admin', make_admin_group_member_path(@group, resource), method: :post
       = ' | '
-      = link_to 'REMOVE', group_member_path(@group, resource), method: :delete, data: { confirm: 'Are you sure?' }
+      = link_to 'Remove from group', group_member_path(@group, resource), method: :delete, data: { confirm: 'Are you sure?' }
+      

--- a/spec/feature/user_interacts_with_groups_spec.rb
+++ b/spec/feature/user_interacts_with_groups_spec.rb
@@ -6,11 +6,11 @@ RSpec.feature 'Interacting with groups' do
     group = create(:group)
 
     visit group_path(group)
-    click_on 'JOIN GROUP'
+    click_on 'Join group'
     wait_for_ajax
 
     expect(group.find_member(user)).not_to be nil
-    expect(page).to have_content('LEAVE GROUP')
+    expect(page).to have_content('Leave group')
   end
 
   scenario 'users can leave an existing group' do
@@ -19,11 +19,11 @@ RSpec.feature 'Interacting with groups' do
     group.add_user(user)
 
     visit group_path(group)
-    click_on 'LEAVE GROUP'
+    click_on 'Leave group'
     wait_for_ajax
 
     expect(group.find_member(user)).to be nil
-    expect(page).to have_content('JOIN GROUP')
+    expect(page).to have_content('Join group')
   end
 
   scenario 'users can\'t edit groups' do
@@ -33,9 +33,7 @@ RSpec.feature 'Interacting with groups' do
     group.add_user(user)
 
     visit group_path(group)
-    click_on 'SETTINGS'
-
-    expect(page).to have_content('You are not authorized to perform this action.')
+    expect(page).not_to have_content('Settings')
   end
 
   scenario 'users can\'t edit members list' do

--- a/spec/feature/user_manages_groups_spec.rb
+++ b/spec/feature/user_manages_groups_spec.rb
@@ -39,8 +39,8 @@ RSpec.feature 'Managing groups' do
 
     expect(find('h1')).to have_content(group.name)
     expect(page).to have_text('New Description.')
-    expect(group.reload.tag_list).to eq %w(some cool tags)
-    expect(group.reload.cached_tags).to eq %w(some cool tags)
+    expect(group.reload.tag_list).to match_array %w(some cool tags)
+    expect(group.reload.cached_tags).to match_array %w(some cool tags)
   end
 
   scenario 'group admins can add and remove members' do

--- a/spec/feature/user_manages_groups_spec.rb
+++ b/spec/feature/user_manages_groups_spec.rb
@@ -14,7 +14,7 @@ RSpec.feature 'Managing groups' do
       fill_in 'group[long_description]', with: group.long_description
       fill_in 'group[url]', with: group.url
       fill_in 'group[email]', with: 'admin@greencommons.org'
-      click_on 'CREATE'
+      click_on 'Create'
     end
     expect(find('h1')).to have_content(group.name)
   end
@@ -22,21 +22,25 @@ RSpec.feature 'Managing groups' do
   scenario 'group admins can update a group' do
     user = feature_login
     group = create(:group)
+    group.tag_list.add('test')
     group.add_admin(user)
 
     visit group_path(group)
-    click_on 'SETTINGS'
+    click_on 'Settings'
     expect(find('h1')).to have_content("Edit #{group.name}")
 
     within("#edit_group_#{group.id}") do
       fill_in 'group[name]', with: group.name
-      fill_in 'group[short_description]', with: 'New Description.'
+      fill_in 'group[long_description]', with: 'New Description.'
+      fill_in 'group[tag_list]', with: 'some, cool, tags'
 
-      click_on 'UPDATE'
+      click_on 'Update'
     end
 
     expect(find('h1')).to have_content(group.name)
     expect(page).to have_text('New Description.')
+    expect(group.reload.tag_list).to eq %w(some cool tags)
+    expect(group.reload.cached_tags).to eq %w(some cool tags)
   end
 
   scenario 'group admins can add and remove members' do
@@ -47,7 +51,7 @@ RSpec.feature 'Managing groups' do
     new_member = create(:user)
 
     visit group_path(group)
-    click_on 'MEMBERS'
+    click_on '1'
 
     within('#top-page-form') do
       fill_in 'email', with: new_member.email
@@ -56,7 +60,7 @@ RSpec.feature 'Managing groups' do
 
     expect(page).to have_text(new_member.email)
 
-    click_on 'REMOVE'
+    click_on 'Remove'
     expect(page).not_to have_text(new_member.email)
   end
 
@@ -69,15 +73,15 @@ RSpec.feature 'Managing groups' do
     group.add_user(new_member)
 
     visit group_path(group)
-    click_on 'MEMBERS'
+    click_on '2'
 
     expect(page).to have_text('2 members')
 
-    click_on 'MAKE ADMIN'
+    click_on 'Make admin'
     wait_for_ajax
     expect(group.admin?(new_member)).to be true
 
-    click_on 'REMOVE ADMIN'
+    click_on 'Remove admin rights'
     wait_for_ajax
     expect(group.admin?(new_member)).to be false
   end


### PR DESCRIPTION
Depends on PR #156.

# Reason for change

A new design has been created for Green Commons and it was requested to update the current design.

# Changes

This pull request includes the new design for all group-related pages:
- Group list (my groups)
- Group show page
- Group Create and Edit
- Group members list (custom made because no design, just reused elements from other pages). Can be accessed by clicking the members count on the group page, there didn't seem to be any other button to access it in the design.

# Screenshots

## My Groups

![screen shot 2560-05-05 at 1 28 34 pm](https://cloud.githubusercontent.com/assets/2647689/25735596/c3a01396-3196-11e7-8c39-94a21ba428e6.png)

## Group Page

![screen shot 2560-05-04 at 11 12 45 pm](https://cloud.githubusercontent.com/assets/2647689/25735564/7ade1ee6-3196-11e7-9a87-418b2292af65.png)

## Group Page (bottom)

![screen shot 2560-05-04 at 11 10 18 pm](https://cloud.githubusercontent.com/assets/2647689/25735568/7f9acec0-3196-11e7-9125-303f87ae677d.png)

# Group form

![screen shot 2560-05-04 at 11 32 55 pm](https://cloud.githubusercontent.com/assets/2647689/25735573/85eaca82-3196-11e7-927d-0b570d2d0729.png)

# Group Members list

![screen shot 2560-05-05 at 12 10 14 pm](https://cloud.githubusercontent.com/assets/2647689/25735574/89d850c4-3196-11e7-9965-bbc28be0b8e7.png)

