### PR TITLE
Dynamic owner search for list form

### DIFF
--- a/app/assets/javascripts/components/add_to_list/add_to_list_form.js.jsx
+++ b/app/assets/javascripts/components/add_to_list/add_to_list_form.js.jsx
@@ -50,6 +50,10 @@ var AddToListForm = React.createClass({
     });
   },
 
+  handleSelect: function(value) {
+    _this.setState({ listId: value });
+  },
+
   componentWillUnmount: function() {
     $('body').removeClass('no-scroll');
   },
@@ -106,8 +110,11 @@ var AddToListForm = React.createClass({
                 <fieldset>
                   <div className="form-group">
                     <label className="control-label" htmlFor="resource_title">List</label>
-                    <select name="list_item[list_id]" id="list_id" aria-hidden="true" onChange={this.handleListId}>
-                    </select>
+                    <AutocompleteSelect name='list_item[list_id]'
+                                        id='list_id'
+                                        autocompletePath={this.props.autocompletePath}
+                                        handler={this.handleSelect}
+                                        remote={true} />
                   </div>
                   <div className="form-group">
                     <label className="control-label" htmlFor="resource_url">Note</label>

--- a/app/assets/javascripts/components/autocomplete_select.js.jsx
+++ b/app/assets/javascripts/components/autocomplete_select.js.jsx
@@ -1,0 +1,62 @@
+var AutocompleteSelect = React.createClass({
+  propTypes: {
+    name: React.PropTypes.string,
+    id: React.PropTypes.string,
+    autocompletePath: React.PropTypes.string,
+    handler: React.PropTypes.func,
+    options: React.PropTypes.array
+  },
+
+  componentDidMount: function() {
+    var _this = this;
+    $('body').addClass('no-scroll');
+
+    if (this.props.autocompletePath) {
+      $('#' + this.props.id).select2({
+        theme: 'bootstrap',
+        data: _this.props.options,
+        ajax: {
+          url: _this.props.autocompletePath,
+          dataType: 'json',
+          delay: 250,
+          data: function (params) {
+            return {
+              q: params.term
+            };
+          },
+          processResults: function (data, params) {
+            return {
+              results: data.items
+            };
+          },
+          cache: true
+        },
+        minimumInputLength: 2,
+        templateResult: function(item) { return item.name; },
+        templateSelection: function(item) { return item.name }
+      })
+    } else {
+      $('#' + this.props.id).select2({
+        theme: 'bootstrap',
+        data: _this.props.options
+      })
+    }
+
+    $('#' + this.props.id).on('change', function(e) {
+      if (_this.props.handler) {
+        _this.props.handler(e.target.value);
+      }
+    });
+  },
+
+  componentWillUnmount: function() {
+    $('body').removeClass('no-scroll');
+  },
+
+  render: function() {
+    return (
+      <select name={this.props.name} id={this.props.id} aria-hidden="true">
+      </select>
+    );
+  }
+});

--- a/app/assets/javascripts/components/create_list/owner_picker.js.jsx
+++ b/app/assets/javascripts/components/create_list/owner_picker.js.jsx
@@ -1,0 +1,18 @@
+var OwnerPicker = React.createClass({
+  propTypes: {
+    autocompletePath: React.PropTypes.string,
+    options: React.PropTypes.array
+  },
+
+  render: function() {
+    return (
+      <div className='form-group'>
+        <label className="control-label" htmlFor="list_owner">Owner</label>
+        <AutocompleteSelect name='list[owner]'
+                            id='list_owner'
+                            autocompletePath={this.props.autocompletePath}
+                            options={this.props.options} />
+      </div>
+    );
+  }
+});

--- a/app/assets/stylesheets/components/_user-picture.scss
+++ b/app/assets/stylesheets/components/_user-picture.scss
@@ -1,5 +1,6 @@
 .user-picture {
   &__image {
+    width: 36px;
     height: 36px;
     border: 1px solid #fff;
     border-radius: 25px;

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -12,6 +12,11 @@ class AutocompleteController < ApplicationController
     render json: { items: lists }
   end
 
+  def list_owners
+    list_owners = Suggesters::ListOwners.new(query: params[:q]).suggest
+    render json: { items: list_owners }
+  end
+
   private
 
   def current_resource

--- a/app/controllers/lists_controller.rb
+++ b/app/controllers/lists_controller.rb
@@ -1,7 +1,6 @@
 class ListsController < ApplicationController
   before_action :authenticate_user!, except: [:show]
   before_action :set_list, only: [:show, :edit, :update, :destroy, :leave]
-  before_action :set_owner_suggestions, only: [:new, :edit]
 
   def index
     @lists = policy_scope(List).page(params[:page] || 1).per(10)
@@ -72,14 +71,10 @@ class ListsController < ApplicationController
     authorize @list
   end
 
-  def set_owner_suggestions
-    @owner_suggestions = Group.all.map { |g| [g.name, "Group:#{g.id}"] } +
-                         User.all.map { |u| [u.name.presence || u.email, "User:#{u.id}"] }
-  end
-
   def owner
+    return nil unless params[:list][:owner]
     owner = params[:list][:owner].split(':')
-    return current_user unless %w(Group User).include?(owner[0])
+    return nil unless %w(Group User).include?(owner[0])
     owner[0].constantize.find(owner[1]) || current_user
   end
 

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -1,0 +1,11 @@
+module TypesHelper
+  def list_owner(owner)
+    name = if owner.is_a?(Group)
+             "#{owner.name} (Group)"
+           else
+             "#{owner.first_name} #{owner.last_name}, #{owner.email} (User)"
+           end
+
+    { id: "#{owner.class}:#{owner.id}", name: name }
+  end
+end

--- a/app/models/concerns/indexable.rb
+++ b/app/models/concerns/indexable.rb
@@ -30,7 +30,7 @@ module Indexable
     end
 
     def set_published_at
-      unless published_at
+      if respond_to?(:published_at) && !published_at
         if defined?(metadata) && metadata && metadata['date']
           begin
             self.published_at = Date.parse(metadata['date'])

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -13,6 +13,30 @@ class Group < ApplicationRecord
 
   validates :name, presence: true
 
+  settings index: { number_of_shards: 2 } do
+    mappings dynamic: true do
+      indexes :id, type: 'long'
+      indexes :name, analyzer: 'english', type: 'string'
+      indexes :short_description, analyzer: 'english', type: 'string'
+      indexes :long_description, analyzer: 'english', type: 'string'
+      indexes :url, type: 'string'
+      indexes :email, analyzer: 'english', type: 'string'
+      indexes :tags, fields: { keyword: { ignore_above: 256, type: 'keyword' } }, type: 'text'
+      indexes :created_at, type: 'date'
+      indexes :published_at, type: 'date'
+      indexes :updated_at, type: 'date'
+
+      indexes :name_suggest, type: 'completion'
+    end
+  end
+
+  def as_indexed_json(_options = {})
+    json = as_json
+    json['tags'] = json.delete('cached_tags')
+    json['name_suggest'] = { input: name.split(' ') }
+    json
+  end
+
   def latest_resources(limit: 4)
     resources.sort_by_created_at.distinct.limit(limit)
   end

--- a/app/models/list.rb
+++ b/app/models/list.rb
@@ -17,7 +17,7 @@ class List < ApplicationRecord
   validates :owner_type, inclusion: %w(User Group)
 
   settings index: { number_of_shards: 2 } do
-    mappings dynamic: 'false' do
+    mappings dynamic: true do
       indexes :id, type: 'long'
       indexes :name, analyzer: 'english', type: 'string'
       indexes :description, analyzer: 'english', type: 'string'

--- a/app/services/suggesters/list_owners.rb
+++ b/app/services/suggesters/list_owners.rb
@@ -1,0 +1,47 @@
+module Suggesters
+  class ListOwners
+    def initialize(query:)
+      @query = query
+    end
+
+    def suggest
+      @records ||= format_records(User) + format_records(Group)
+    end
+
+    private
+
+    def format_records(klass)
+      records = es_records(klass)
+      return [] unless records['suggest'] && records['suggest']['owner_suggest'].any?
+
+      records['suggest']['owner_suggest'].first['options'].map do |l|
+        {
+          id: "#{klass}:#{l['_source']['id']}",
+          name: "#{l['_source']['name'] || user_name(l)} (#{klass})"
+        }
+      end
+    end
+
+    def user_name(l)
+      "#{l['_source']['first_name']} #{l['_source']['last_name']}, #{l['_source']['email']}".strip
+    end
+
+    def es_records(klass)
+      @es_records = klass.__elasticsearch__.client.search(index: klass.index_name,
+                                                          body: es_params)
+    end
+
+    def es_params
+      @es_params ||= {
+        suggest: {
+          owner_suggest: {
+            text: @query,
+            completion: {
+              field: 'name_suggest'
+            }
+          }
+        }
+      }
+    end
+  end
+end

--- a/app/services/suggesters/lists.rb
+++ b/app/services/suggesters/lists.rb
@@ -12,6 +12,8 @@ module Suggesters
     private
 
     def format_records
+      return [] unless es_records['suggest'] && es_records['suggest']['owner_suggest'].any?
+
       formatted_records = es_records['suggest']['list_suggest'].first['options'].map do |l|
         { id: l['_source']['id'], name: l['_source']['name'] }
       end

--- a/app/views/lists/_form.html.slim
+++ b/app/views/lists/_form.html.slim
@@ -15,9 +15,8 @@
         .form-group
           = f.label :name, 'Name', class: 'control-label'
           = f.text_field :name, class: 'form-control', placeholder: 'List name...'
-        .form-group
-          = f.label :owner, 'Owner', class: 'control-label'
-          = f.select :owner, @owner_suggestions, {}, data: { gcselect2: true }
+        = react_component 'OwnerPicker', { autocompletePath: autocomplete_list_owners_path,
+                                           options: list.owner ? [list_owner(list.owner)] : [] }
         .form-group
           = f.label :description, class: 'control-label'
           = f.text_area :description, class: 'form-control', placeholder: '300 characters max'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
   end
   get '/autocomplete/members', to: 'autocomplete#members', as: 'autocomplete_members'
   get '/autocomplete/lists/:current_resource', to: 'autocomplete#lists', as: 'autocomplete_lists'
+  get '/autocomplete/lists_owners', to: 'autocomplete#list_owners', as: 'autocomplete_list_owners'
 
   # User-facing routes
   resources :search, only: [:new]

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -8,7 +8,7 @@ namespace :elasticsearch do
       client.indices.delete index: klass.index_name
     end
 
-    klass.__elasticsearch__.create_index!
+    klass.__elasticsearch__.create_index! force: true
 
     begin
       klass.import
@@ -21,7 +21,7 @@ namespace :elasticsearch do
 
   desc 'Deletes the "resource", "group" and "list" indices and regenerates it with all records'
   task reset_all_indices: :environment do
-    [Resource, Group, List].each { |klass| reset_index(klass) }
+    [Resource, Group, List, User].each { |klass| reset_index(klass) }
   end
 
   desc 'Deletes the "resource" index and regenerates it with all records currently in Resource'
@@ -37,5 +37,10 @@ namespace :elasticsearch do
   desc 'Deletes the "list" index and regenerates it with all records currently in List'
   task reset_list_index: :environment do
     reset_index(List)
+  end
+
+  desc 'Deletes the "user" index and regenerates it with all records currently in List'
+  task reset_list_index: :environment do
+    reset_index(User)
   end
 end

--- a/spec/feature/user_manages_lists_spec.rb
+++ b/spec/feature/user_manages_lists_spec.rb
@@ -22,7 +22,40 @@ RSpec.feature 'Managing lists', :worker, :elasticsearch do
     expect(page).to have_text('Some description.')
   end
 
-  scenario 'users can create a list' do
+  scenario 'users can create a private list owned by a group' do
+    user = feature_login
+    group = create(:group, name: 'test')
+    wait_for { User.search(user.email).results.total }.to eq(1)
+    wait_for { Group.search(group.name).results.total }.to eq(1)
+
+    find(:css, '.glyphicon.glyphicon-plus').click
+    click_link 'Create List'
+
+    within('#new_list') do
+      fill_in 'list[name]', with: 'My list'
+      fill_in 'list[description]', with: 'Description!'
+      find('.select2-selection').click
+      find(:xpath, "//input[@class='select2-search__field']").set 'te'
+      wait_for_ajax
+      find(:xpath, "//li[@class='select2-results__option select2-results__option--highlighted']").
+        click
+
+      fill_in 'list[description]', with: 'Description!'
+      find('.bootstrap-tagsinput').find('input').set('some,random,tags')
+      click_on 'Create'
+    end
+
+    expect(find('h1')).to have_content('My list')
+    expect(List.count).to eq 1
+    expect(List.first.privacy).to eq 'publ'
+    expect(List.first.owner).to eq group
+    expect(List.first.description).to eq 'Description!'
+    expect(page).to have_content('some')
+    expect(page).to have_content('random')
+    expect(page).to have_content('tags')
+  end
+
+  scenario 'users can create a private list owner by a user' do
     user = feature_login
 
     find(:css, '.glyphicon.glyphicon-plus').click
@@ -31,35 +64,22 @@ RSpec.feature 'Managing lists', :worker, :elasticsearch do
     within('#new_list') do
       fill_in 'list[name]', with: 'My list'
       fill_in 'list[description]', with: 'Description!'
+      find('.select2-selection').click
+      find(:xpath, "//input[@class='select2-search__field']").set 'ad'
+      wait_for_ajax
+      find(:xpath, "//li[@class='select2-results__option select2-results__option--highlighted']").
+        click
+
+      fill_in 'list[description]', with: 'Description!'
+      find(:css, '#list_privacy').set(true)
       find('.bootstrap-tagsinput').find('input').set('some,random,tags')
       click_on 'Create'
     end
 
     expect(find('h1')).to have_content('My list')
     expect(List.count).to eq 1
-    expect(List.first.owner).to eq user
-    expect(List.first.privacy).to eq 'publ'
-    expect(page).to have_content('some')
-    expect(page).to have_content('random')
-    expect(page).to have_content('tags')
-  end
-
-  scenario 'users can create a private list' do
-    feature_login
-
-    find(:css, '.glyphicon.glyphicon-plus').click
-    click_link 'Create List'
-
-    within('#new_list') do
-      fill_in 'list[name]', with: 'My list'
-      fill_in 'list[description]', with: 'Description!'
-      find(:css, '#list_privacy').set(true)
-      click_on 'Create'
-    end
-
-    expect(find('h1')).to have_content('My list')
-    expect(List.count).to eq 1
     expect(List.first.privacy).to eq 'priv'
+    expect(List.first.owner).to eq user
   end
 
   scenario 'users can update a list' do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -78,7 +78,7 @@ RSpec.configure do |config|
   end
 
   def reset_all_indices
-    [Resource, List, Group].each do |klass|
+    [Resource, List, Group, User].each do |klass|
       klass.__elasticsearch__.delete_index!(index: klass.index_name)
       klass.__elasticsearch__.create_index!(index: klass.index_name)
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -79,8 +79,9 @@ RSpec.configure do |config|
 
   def reset_all_indices
     [Resource, List, Group, User].each do |klass|
+      p "Creating indice for #{klass}..."
       klass.__elasticsearch__.delete_index!(index: klass.index_name)
-      klass.__elasticsearch__.create_index!(index: klass.index_name)
+      p klass.__elasticsearch__.create_index!(index: klass.index_name)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -31,7 +31,7 @@ RSpec.configure do |config|
   config.before(:suite) do
     DatabaseCleaner.clean_with(:truncation)
 
-    [Resource, List, Group].each do |klass|
+    [Resource, List, Group, User].each do |klass|
       klass.__elasticsearch__.create_index!(index: klass.index_name)
     end
   end
@@ -79,10 +79,8 @@ RSpec.configure do |config|
 
   def reset_all_indices
     [Resource, List, Group, User].each do |klass|
-      p "Creating indice for #{klass}..."
-      p klass.__elasticsearch__.delete_index!(index: klass.index_name)
-      p klass.__elasticsearch__.create_index!(index: klass.index_name)
-      p 'Index created.'
+      klass.__elasticsearch__.delete_index!(index: klass.index_name)
+      klass.__elasticsearch__.create_index!(index: klass.index_name)
     end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -80,8 +80,9 @@ RSpec.configure do |config|
   def reset_all_indices
     [Resource, List, Group, User].each do |klass|
       p "Creating indice for #{klass}..."
-      klass.__elasticsearch__.delete_index!(index: klass.index_name)
+      p klass.__elasticsearch__.delete_index!(index: klass.index_name)
       p klass.__elasticsearch__.create_index!(index: klass.index_name)
+      p 'Index created.'
     end
   end
 end


### PR DESCRIPTION
# Reason for change

In the current implementation, we load all the groups/users to fill the `select` options. This is not a viable solution on the long term and we need to switch to a remote autocomplete style.

# Changes

- Set up Users to be indexed in ES.
- Added mappings for the Group model (for ES).
- Replace owner select in List form to be a React component (using `select2`) that will retrieve suggestions from the server when the user starts typing.

# Note

If having both groups and users in the same results becomes too annoying (like a user cannot find a user because too many groups match his query), we could add another select above letting the user pick which type of owner he wants to set, and only search for that specific type after that.