### PR TITLE
Improve Add To List dropdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ gem 'font-awesome-rails'
 gem 'momentjs-rails'
 gem 'bootstrap-daterangepicker-rails'
 gem 'bootstrap-tagsinput-rails'
-gem 'select2-rails'
+gem 'selectize-rails'
 
 group :development do
   gem 'bummr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -348,8 +348,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    select2-rails (4.0.3)
-      thor (~> 0.14)
+    selectize-rails (0.12.4)
     shellany (0.0.1)
     shoulda (3.5.0)
       shoulda-context (~> 1.0, >= 1.0.1)
@@ -450,7 +449,7 @@ DEPENDENCIES
   rubocop
   rubocop-rspec
   sass-rails (~> 5.0)
-  select2-rails
+  selectize-rails
   shoulda
   sidekiq
   slim

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -8,7 +8,7 @@
 //= require moment
 //= require daterangepicker
 //= require bootstrap-tagsinput
-//= require select2
+//= require selectize
 
 //= require form
 

--- a/app/assets/javascripts/components/add_to_list/add_to_list_button.js.jsx
+++ b/app/assets/javascripts/components/add_to_list/add_to_list_button.js.jsx
@@ -9,7 +9,8 @@ var AddToListButton = React.createClass({
     autocomplete_path: React.PropTypes.string,
     authenticity_token: React.PropTypes.string,
     button_class: React.PropTypes.string,
-    logged_in: React.PropTypes.bool
+    logged_in: React.PropTypes.bool,
+    options: React.PropTypes.array
   },
 
   getInitialState: function() {
@@ -41,7 +42,8 @@ var AddToListButton = React.createClass({
                         authenticityToken={this.props.authenticity_token}
                         toggleModal={this.toggleModal}
                         updateListCount={this.updateListCount}
-                        loggedIn={this.props.logged_in} />
+                        loggedIn={this.props.logged_in}
+                        options={this.props.options} />
       )
     }
 

--- a/app/assets/javascripts/components/add_to_list/add_to_list_form.js.jsx
+++ b/app/assets/javascripts/components/add_to_list/add_to_list_form.js.jsx
@@ -8,7 +8,8 @@ var AddToListForm = React.createClass({
     authenticityToken: React.PropTypes.string,
     toggleModal: React.PropTypes.func,
     load: React.PropTypes.func,
-    confirm: React.PropTypes.func
+    confirm: React.PropTypes.func,
+    options: React.PropTypes.array
   },
 
   getInitialState: function() {
@@ -16,38 +17,6 @@ var AddToListForm = React.createClass({
       listId: null,
       note: ''
     }
-  },
-
-  componentDidMount: function() {
-    var _this = this;
-    $('body').addClass('no-scroll');
-
-    $('#list_id').select2({
-      theme: 'bootstrap',
-      ajax: {
-        url: _this.props.autocompletePath,
-        dataType: 'json',
-        delay: 250,
-        data: function (params) {
-          return {
-            q: params.term
-          };
-        },
-        processResults: function (data, params) {
-          return {
-            results: data.items
-          };
-        },
-        cache: true
-      },
-      minimumInputLength: 2,
-      templateResult: function(list) { return list.name; },
-      templateSelection: function(list) { return list.name }
-    })
-
-    $('#list_id').on('change', function(e) {
-      _this.setState({ listId: e.target.value });
-    });
   },
 
   handleSelect: function(value) {
@@ -114,7 +83,7 @@ var AddToListForm = React.createClass({
                                         id='list_id'
                                         autocompletePath={this.props.autocompletePath}
                                         handler={this.handleSelect}
-                                        remote={true} />
+                                        options={this.props.options} />
                   </div>
                   <div className="form-group">
                     <label className="control-label" htmlFor="resource_url">Note</label>

--- a/app/assets/javascripts/components/add_to_list/add_to_list_loading.js.jsx
+++ b/app/assets/javascripts/components/add_to_list/add_to_list_loading.js.jsx
@@ -22,7 +22,7 @@ var AddToListLoading = React.createClass({
         </div>
         <div className="form-box__body">
           <div className="row">
-            <div className="col-xs-12">
+            <div className="col-xs-4 col-xs-offset-4">
               <div className='text-center'>
                 <img src={this.props.loaderImage}></img>
               </div>

--- a/app/assets/javascripts/components/add_to_list/add_to_list_modal.js.jsx
+++ b/app/assets/javascripts/components/add_to_list/add_to_list_modal.js.jsx
@@ -10,6 +10,7 @@ var AddToListModal = React.createClass({
     toggleModal: React.PropTypes.func,
     updateListCount: React.PropTypes.func,
     loggedIn: React.PropTypes.bool,
+    options: React.PropTypes.array
   },
 
   getInitialState: function() {
@@ -49,7 +50,8 @@ var AddToListModal = React.createClass({
                          authenticityToken={this.props.authenticityToken}
                          toggleModal={this.props.toggleModal}
                          load={this.load}
-                         confirm={this.confirm} />
+                         confirm={this.confirm}
+                         options={this.props.options} />
         )
         break;
       case 'loading':

--- a/app/assets/javascripts/components/create_list/owner_picker.js.jsx
+++ b/app/assets/javascripts/components/create_list/owner_picker.js.jsx
@@ -1,7 +1,8 @@
 var OwnerPicker = React.createClass({
   propTypes: {
     autocompletePath: React.PropTypes.string,
-    options: React.PropTypes.array
+    options: React.PropTypes.array,
+    selected: React.PropTypes.string
   },
 
   render: function() {
@@ -11,7 +12,8 @@ var OwnerPicker = React.createClass({
         <AutocompleteSelect name='list[owner]'
                             id='list_owner'
                             autocompletePath={this.props.autocompletePath}
-                            options={this.props.options} />
+                            options={this.props.options}
+                            selected={this.props.selected} />
       </div>
     );
   }

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -5,8 +5,8 @@
 @import "daterangepicker-bs3";
 @import "theme/bootswatch";
 @import 'bootstrap-tagsinput.scss';
-@import 'select2';
-@import 'select2-bootstrap';
+@import 'selectize';
+@import 'selectize.bootstrap3';
 
 @import "helpers/colors";
 @import "helpers/glyphicons";

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -7,8 +7,11 @@ class AutocompleteController < ApplicationController
   end
 
   def lists
+    existing_lists = current_user.group_owned_lists.pluck(:id)
+    allowed_lists = current_user.owned_lists.where.not(id: existing_lists) +
+                      current_user.group_owned_lists.where.not(id: existing_lists)
     lists = Suggesters::Lists.new(query: params[:q],
-                                  except: current_resource.lists).suggest
+                                  only: allowed_lists).suggest
     render json: { items: lists }
   end
 

--- a/app/controllers/autocomplete_controller.rb
+++ b/app/controllers/autocomplete_controller.rb
@@ -7,9 +7,8 @@ class AutocompleteController < ApplicationController
   end
 
   def lists
-    existing_lists = current_user.group_owned_lists.pluck(:id)
-    allowed_lists = current_user.owned_lists.where.not(id: existing_lists) +
-                      current_user.group_owned_lists.where.not(id: existing_lists)
+    allowed_lists = current_user.all_owned_lists.
+                    where.not(id: current_resource.lists.pluck(:id))
     lists = Suggesters::Lists.new(query: params[:q],
                                   only: allowed_lists).suggest
     render json: { items: lists }

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -1,5 +1,5 @@
 module TypesHelper
-  def list_owner(user, _list)
+  def list_options(user)
     suggestions = current_user.groups.order('groups_users.created_at DESC').limit(5).to_a
     suggestions.unshift(user)
     suggestions.map do |suggestion|
@@ -10,7 +10,7 @@ module TypesHelper
     end
   end
 
-  def user_lists(user, resource)
+  def owner_options(user, resource)
     user.all_owned_lists.where.not(id: resource.lists.pluck(:id)).limit(5).map do |l|
       { id: l.id, name: l.name }
     end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -8,4 +8,10 @@ module TypesHelper
 
     { id: "#{owner.class}:#{owner.id}", name: name }
   end
+
+  def user_lists(user, resource)
+    user.owned_lists.where.not(id: resource.lists.pluck(:id)).limit(5).map do |l|
+      { id: l.id, name: l.name }
+    end
+  end
 end

--- a/app/helpers/types_helper.rb
+++ b/app/helpers/types_helper.rb
@@ -1,17 +1,28 @@
 module TypesHelper
-  def list_owner(owner)
-    name = if owner.is_a?(Group)
-             "#{owner.name} (Group)"
-           else
-             "#{owner.first_name} #{owner.last_name}, #{owner.email} (User)"
-           end
-
-    { id: "#{owner.class}:#{owner.id}", name: name }
+  def list_owner(user, _list)
+    suggestions = current_user.groups.order('groups_users.created_at DESC').limit(5).to_a
+    suggestions.unshift(user)
+    suggestions.map do |suggestion|
+      {
+        id: "#{suggestion.class}:#{suggestion.id}",
+        name: owner_name(suggestion)
+      }
+    end
   end
 
   def user_lists(user, resource)
-    user.owned_lists.where.not(id: resource.lists.pluck(:id)).limit(5).map do |l|
+    user.all_owned_lists.where.not(id: resource.lists.pluck(:id)).limit(5).map do |l|
       { id: l.id, name: l.name }
+    end
+  end
+
+  private
+
+  def owner_name(suggestion)
+    if suggestion.is_a?(Group)
+      "#{suggestion.name} (Group)"
+    else
+      "#{suggestion.first_name} #{suggestion.last_name}, #{suggestion.email} (User)"
     end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -38,6 +38,11 @@ class User < ApplicationRecord
     end
   end
 
+  def all_owned_lists
+    List.where(owner_type: 'User', owner_id: id).
+      or(List.where(owner_type: 'Group', owner_id: groups.pluck(:id)))
+  end
+
   def as_indexed_json(_options = {})
     json = as_json
     json['name_suggest'] = { input: [first_name ? first_name.split(' ') : nil,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   has_many :groups_users
   has_many :groups, through: :groups_users
   has_many :owned_lists, as: :owner, class_name: List
+  has_many :group_owned_lists, through: :groups, source: :lists, class_name: List
 
   validates :email, presence: true, uniqueness: true
   validates :first_name, length: { maximum: 255 }

--- a/app/policies/list_policy.rb
+++ b/app/policies/list_policy.rb
@@ -37,7 +37,7 @@ class ListPolicy < ApplicationPolicy
 
   def owned?
     if @list.owner.is_a?(Group)
-      @list.owner.admin?(@user)
+      !@list.owner.find_member(@user).nil?
     else
       @list.owner == @user
     end

--- a/app/services/suggesters/lists.rb
+++ b/app/services/suggesters/lists.rb
@@ -1,9 +1,8 @@
 module Suggesters
   class Lists
-    def initialize(query:, only: [], except: [])
+    def initialize(query:, only: [])
       @query = query
       @only = only.map { |e| [e.id, e.class.name] }
-      @except = [*except].compact.map { |e| [e.id, e.class.name] }
     end
 
     def suggest
@@ -18,11 +17,10 @@ module Suggesters
       formatted_records = es_records['suggest']['list_suggest'].first['options'].map do |l|
         { id: l['_source']['id'], name: l['_source']['name'] }
       end
-      return formatted_records unless @except.any? || @only.any?
+      return formatted_records unless @only.any?
 
       formatted_records.reject do |r|
-        (@only.any? && !@only.include?([r[:id], 'List'])) ||
-          (@except.any? && @except.include?([r[:id], 'List']))
+        @only.any? && !@only.include?([r[:id], 'List'])
       end
     end
 

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -84,9 +84,8 @@
                                                            authenticity_token: form_authenticity_token,
                                                            list_count: @group.lists.count,
                                                            button_class: "btn-groups btn--large",
-                                                           logged_in: current_user.present? }
-
-
+                                                           logged_in: current_user.present?,
+                                                           options: current_user ? user_lists(current_user, @group) : [] }
 
             .resource-page__content
               .row

--- a/app/views/groups/show.html.slim
+++ b/app/views/groups/show.html.slim
@@ -85,7 +85,7 @@
                                                            list_count: @group.lists.count,
                                                            button_class: "btn-groups btn--large",
                                                            logged_in: current_user.present?,
-                                                           options: current_user ? user_lists(current_user, @group) : [] }
+                                                           options: current_user ? owner_options(current_user, @group) : [] }
 
             .resource-page__content
               .row

--- a/app/views/lists/_form.html.slim
+++ b/app/views/lists/_form.html.slim
@@ -16,7 +16,7 @@
           = f.label :name, 'Name', class: 'control-label'
           = f.text_field :name, class: 'form-control', placeholder: 'List name...'
         = react_component 'OwnerPicker', { autocompletePath: autocomplete_list_owners_path,
-                                           options: list_owner(current_user, list),
+                                           options: list_options(current_user),
                                            selected: list.owner ? "#{list.owner.class}:#{list.owner.id}" : nil }
         .form-group
           = f.label :description, class: 'control-label'

--- a/app/views/lists/_form.html.slim
+++ b/app/views/lists/_form.html.slim
@@ -16,7 +16,7 @@
           = f.label :name, 'Name', class: 'control-label'
           = f.text_field :name, class: 'form-control', placeholder: 'List name...'
         = react_component 'OwnerPicker', { autocompletePath: autocomplete_list_owners_path,
-                                           options: list.owner ? [list_owner(list.owner)] : [],
+                                           options: list_owner(current_user, list),
                                            selected: list.owner ? "#{list.owner.class}:#{list.owner.id}" : nil }
         .form-group
           = f.label :description, class: 'control-label'

--- a/app/views/lists/_form.html.slim
+++ b/app/views/lists/_form.html.slim
@@ -16,7 +16,8 @@
           = f.label :name, 'Name', class: 'control-label'
           = f.text_field :name, class: 'form-control', placeholder: 'List name...'
         = react_component 'OwnerPicker', { autocompletePath: autocomplete_list_owners_path,
-                                           options: list.owner ? [list_owner(list.owner)] : [] }
+                                           options: list.owner ? [list_owner(list.owner)] : [],
+                                           selected: list.owner ? "#{list.owner.class}:#{list.owner.id}" : nil }
         .form-group
           = f.label :description, class: 'control-label'
           = f.text_area :description, class: 'form-control', placeholder: '300 characters max'

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -87,7 +87,8 @@
                                                            authenticity_token: form_authenticity_token,
                                                            list_count: @resource.lists.count,
                                                            button_class: "btn-#{@resource.resource_type} btn--large",
-                                                           logged_in: current_user.present? }
+                                                           logged_in: current_user.present?,
+                                                           options: current_user ? user_lists(current_user, @resource) : [] }
 
 
             .resource-page__content

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -88,7 +88,7 @@
                                                            list_count: @resource.lists.count,
                                                            button_class: "btn-#{@resource.resource_type} btn--large",
                                                            logged_in: current_user.present?,
-                                                           options: current_user ? user_lists(current_user, @resource) : [] }
+                                                           options: current_user ? owner_options(current_user, @resource) : [] }
 
 
             .resource-page__content

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -30,7 +30,8 @@
                                                  authenticity_token: form_authenticity_token,
                                                  list_count: resource.lists.count,
                                                  button_class: "btn-gc",
-                                                 logged_in: current_user.present? }
+                                                 logged_in: current_user.present?,
+                                                 options: current_user ? user_lists(current_user, resource) : [] }
         .summary-card__more.summary-card__more--meta
           .summary-card__metadata.summary-card__metadata--last
             i.fa.fa-th-list.glyphicon--right

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -31,7 +31,7 @@
                                                  list_count: resource.lists.count,
                                                  button_class: "btn-gc",
                                                  logged_in: current_user.present?,
-                                                 options: current_user ? user_lists(current_user, resource) : [] }
+                                                 options: current_user ? owner_options(current_user, resource) : [] }
         .summary-card__more.summary-card__more--meta
           .summary-card__metadata.summary-card__metadata--last
             i.fa.fa-th-list.glyphicon--right

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -43,7 +43,7 @@
                                                  list_count: resource.lists.count,
                                                  button_class: "btn-gc",
                                                  logged_in: current_user.present?,
-                                                 options: current_user ? user_lists(current_user, resource) : [] }
+                                                 options: current_user ? owner_options(current_user, resource) : [] }
         .summary-card__more.summary-card__more--meta
           .summary-card__metadata.summary-card__metadata--last
             i.fa.fa-pencil.glyphicon--right

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -42,7 +42,8 @@
                                                  authenticity_token: form_authenticity_token,
                                                  list_count: resource.lists.count,
                                                  button_class: "btn-gc",
-                                                 logged_in: current_user.present? }
+                                                 logged_in: current_user.present?,
+                                                 options: current_user ? user_lists(current_user, resource) : [] }
         .summary-card__more.summary-card__more--meta
           .summary-card__metadata.summary-card__metadata--last
             i.fa.fa-pencil.glyphicon--right

--- a/spec/feature/user_manages_lists_spec.rb
+++ b/spec/feature/user_manages_lists_spec.rb
@@ -34,11 +34,10 @@ RSpec.feature 'Managing lists', :worker, :elasticsearch do
     within('#new_list') do
       fill_in 'list[name]', with: 'My list'
       fill_in 'list[description]', with: 'Description!'
-      find('.select2-selection').click
-      find(:xpath, "//input[@class='select2-search__field']").set 'te'
+      find('.selectize-input').click
+      find('#list_owner-selectized').set 'te'
       wait_for_ajax
-      find(:xpath, "//li[@class='select2-results__option select2-results__option--highlighted']").
-        click
+      find(:xpath, "//div[@class='option active']").click
 
       fill_in 'list[description]', with: 'Description!'
       find('.bootstrap-tagsinput').find('input').set('some,random,tags')
@@ -64,11 +63,11 @@ RSpec.feature 'Managing lists', :worker, :elasticsearch do
     within('#new_list') do
       fill_in 'list[name]', with: 'My list'
       fill_in 'list[description]', with: 'Description!'
-      find('.select2-selection').click
-      find(:xpath, "//input[@class='select2-search__field']").set 'ad'
+
+      find('.selectize-input').click
+      find('#list_owner-selectized').set 'ad'
       wait_for_ajax
-      find(:xpath, "//li[@class='select2-results__option select2-results__option--highlighted']").
-        click
+      find(:xpath, "//div[@class='option active']").click
 
       fill_in 'list[description]', with: 'Description!'
       find(:css, '#list_privacy').set(true)

--- a/spec/feature/user_manages_lists_spec.rb
+++ b/spec/feature/user_manages_lists_spec.rb
@@ -22,63 +22,86 @@ RSpec.feature 'Managing lists', :worker, :elasticsearch do
     expect(page).to have_text('Some description.')
   end
 
-  scenario 'users can create a private list owned by a group' do
-    user = feature_login
-    group = create(:group, name: 'test')
-    wait_for { User.search(user.email).results.total }.to eq(1)
-    wait_for { Group.search(group.name).results.total }.to eq(1)
+  describe 'create a list' do
+    scenario 'users can see themselves and 5 of their groups as suggestions' do
+      user = feature_login
+      user.update_columns(first_name: 'John', last_name: 'Doe')
+      group = create(:group, name: 'test')
+      group.add_user(user)
+      wait_for { User.search(user.email).results.total }.to eq(1)
+      wait_for { Group.search(group.name).results.total }.to eq(1)
 
-    find(:css, '.glyphicon.glyphicon-plus').click
-    click_link 'Create List'
+      find(:css, '.glyphicon.glyphicon-plus').click
+      click_link 'Create List'
 
-    within('#new_list') do
-      fill_in 'list[name]', with: 'My list'
-      fill_in 'list[description]', with: 'Description!'
-      find('.selectize-input').click
-      find('#list_owner-selectized').set 'te'
-      wait_for_ajax
-      find(:xpath, "//div[@class='option active']").click
+      within('#new_list') do
+        fill_in 'list[name]', with: 'My list'
+        fill_in 'list[description]', with: 'Description!'
+        find('.selectize-input').click
+      end
 
-      fill_in 'list[description]', with: 'Description!'
-      find('.bootstrap-tagsinput').find('input').set('some,random,tags')
-      click_on 'Create'
+      expect(page).to have_text "John Doe, #{user.email} (User)"
+      expect(page).to have_text "#{group.name} (Group)"
     end
 
-    expect(find('h1')).to have_content('My list')
-    expect(List.count).to eq 1
-    expect(List.first.privacy).to eq 'publ'
-    expect(List.first.owner).to eq group
-    expect(List.first.description).to eq 'Description!'
-    expect(page).to have_content('some')
-    expect(page).to have_content('random')
-    expect(page).to have_content('tags')
-  end
+    scenario 'users can create a private list owned by a group' do
+      user = feature_login
+      group = create(:group, name: 'test')
+      wait_for { User.search(user.email).results.total }.to eq(1)
+      wait_for { Group.search(group.name).results.total }.to eq(1)
 
-  scenario 'users can create a private list owner by a user' do
-    user = feature_login
+      find(:css, '.glyphicon.glyphicon-plus').click
+      click_link 'Create List'
 
-    find(:css, '.glyphicon.glyphicon-plus').click
-    click_link 'Create List'
+      within('#new_list') do
+        fill_in 'list[name]', with: 'My list'
+        fill_in 'list[description]', with: 'Description!'
+        find('.selectize-input').click
+        find('#list_owner-selectized').set 'te'
+        wait_for_ajax
+        find(:xpath, "//div[@class='option active']").click
 
-    within('#new_list') do
-      fill_in 'list[name]', with: 'My list'
-      fill_in 'list[description]', with: 'Description!'
+        fill_in 'list[description]', with: 'Description!'
+        find('.bootstrap-tagsinput').find('input').set('some,random,tags')
+        click_on 'Create'
+      end
 
-      find('.selectize-input').click
-      find('#list_owner-selectized').set 'ad'
-      wait_for_ajax
-      find(:xpath, "//div[@class='option active']").click
-
-      fill_in 'list[description]', with: 'Description!'
-      find(:css, '#list_privacy').set(true)
-      find('.bootstrap-tagsinput').find('input').set('some,random,tags')
-      click_on 'Create'
+      expect(find('h1')).to have_content('My list')
+      expect(List.count).to eq 1
+      expect(List.first.privacy).to eq 'publ'
+      expect(List.first.owner).to eq group
+      expect(List.first.description).to eq 'Description!'
+      expect(page).to have_content('some')
+      expect(page).to have_content('random')
+      expect(page).to have_content('tags')
     end
 
-    expect(find('h1')).to have_content('My list')
-    expect(List.count).to eq 1
-    expect(List.first.privacy).to eq 'priv'
-    expect(List.first.owner).to eq user
+    scenario 'users can create a private list owner by a user' do
+      user = feature_login
+
+      find(:css, '.glyphicon.glyphicon-plus').click
+      click_link 'Create List'
+
+      within('#new_list') do
+        fill_in 'list[name]', with: 'My list'
+        fill_in 'list[description]', with: 'Description!'
+
+        find('.selectize-input').click
+        find('#list_owner-selectized').set 'ad'
+        wait_for_ajax
+        find(:xpath, "//div[@class='option active']").click
+
+        fill_in 'list[description]', with: 'Description!'
+        find(:css, '#list_privacy').set(true)
+        find('.bootstrap-tagsinput').find('input').set('some,random,tags')
+        click_on 'Create'
+      end
+
+      expect(find('h1')).to have_content('My list')
+      expect(List.count).to eq 1
+      expect(List.first.privacy).to eq 'priv'
+      expect(List.first.owner).to eq user
+    end
   end
 
   scenario 'users can update a list' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,12 +20,28 @@ RSpec.describe User do
     it { is_expected.to have_many(:groups_users) }
     it { is_expected.to have_many(:groups) }
     it { is_expected.to have_many(:owned_lists) }
+    it { is_expected.to have_many(:group_owned_lists) }
   end
 
   describe '#full_name' do
     it 'builds the full_name using first_name and last_name' do
       user = build(:user, first_name: 'John', last_name: 'Wick')
       expect(user.full_name).to eq 'John Wick'
+    end
+  end
+
+  describe '#all_owned_lists' do
+    it 'returns all the lists owned by the user and by groups the user belongs to' do
+      user = create(:user)
+      group1 = create(:group)
+      group2 = create(:group)
+      group1.add_user(user)
+      group2.add_user(user)
+      list1 = create(:list, owner: user)
+      list2 = create(:list, owner: group1)
+      list3 = create(:list, owner: group2)
+
+      expect(user.all_owned_lists).to match_array([list1, list2, list3])
     end
   end
 end

--- a/spec/policies/list_policy_spec.rb
+++ b/spec/policies/list_policy_spec.rb
@@ -47,10 +47,10 @@ describe ListPolicy do
       it { is_expected.to permit_action(:destroy) }
     end
 
-    context 'when list is owned by a group where the user is admin' do
+    context 'when list is owned by a group where the user is a member' do
       before do
         group = create(:group)
-        group.add_admin(user)
+        group.add_user(user)
         list.owner = group
         list.save
       end

--- a/spec/services/suggesters/lists_spec.rb
+++ b/spec/services/suggesters/lists_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe Suggesters::Lists do
+  describe '#suggest', :worker, :elasticsearch do
+    let(:list1) { create(:list, name: 'test 1') }
+    let(:list2) { create(:list, name: 'test 2') }
+    let(:list3) { create(:list, name: 'test 3') }
+    let(:list4) { create(:list, name: 'something else') }
+
+    before do
+      list1 && list2 && list3 && list4
+      wait_for { Suggesters::Lists.new(query: 'test').suggest.size }.to eq(3)
+    end
+
+    context 'without the only parameter' do
+      it 'only returns all the matching lists' do
+        lists = Suggesters::Lists.new(query: 'test').suggest
+        expect(lists).to eq [
+          { id: list1.id, name: 'test 1' },
+          { id: list2.id, name: 'test 2' },
+          { id: list3.id, name: 'test 3' }
+        ]
+      end
+    end
+
+    context 'with the only parameter' do
+      it 'only returns the first list' do
+        lists = Suggesters::Lists.new(query: 'test', only: [list1]).suggest
+        expect(lists).to eq [{ id: list1.id, name: 'test 1' }]
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Reason For Change

Currently the dropdown to add a resource to a list doesn't show any list. It would be nice to show 5 lists owned by the current user to make things easier.

# Changes

- Switch to Selectize from Select2 in order to correctly pre-populate the select
- Allow any user belonging to a group owning a list to edit it
- Change the add to list feature to only allow a user to add to lists he owns or belongs to a group owning them