### PR TITLE
Web API - User Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -425,3 +425,25 @@ curl http://greencommons.herokuapp.com/api/v1/lists/:id/relationships/items \
      -H 'Content-Type: application/vnd.api+json' \
      -d '{ "data": [{ "id": "1", "type": "groups" }, { "id": "1", "type": "resources" }] }'
 ```
+
+#### Users
+
+##### Create users
+
+```
+curl http://greencommons.herokuapp.com/api/v1/users \
+     -X POST \
+     -H 'Authorization: GC aXq8R267J_v1uXk5pbvU5g:1f9413d519c881a5cfc3c15faf6cd17e' \
+     -H 'Content-Type: application/vnd.api+json' \
+     -d '{ "data": { "type": "users", "attributes": { "email": "john@example.com", "password": "password", "password_confirmation": "password"} } }'
+```
+
+##### Update user
+
+```
+curl http://greencommons.herokuapp.com/api/v1/users/:id \
+     -X PATCH \
+     -H 'Authorization: GC aXq8R267J_v1uXk5pbvU5g:1f9413d519c881a5cfc3c15faf6cd17e' \
+     -H 'Content-Type: application/vnd.api+json' \
+     -d '{ "data": { "id": ":id", "type": "users", "attributes": { "first_name": "John" } } }'
+```

--- a/app/controllers/api/api_controller.rb
+++ b/app/controllers/api/api_controller.rb
@@ -7,6 +7,7 @@ module Api
     before_action :set_paper_trail_whodunnit
 
     rescue_from StandardError, with: :server_error
+    rescue_from ActionController::RoutingError, with: :not_found
     rescue_from ActiveRecord::RecordNotFound, with: :not_found
     rescue_from Pundit::NotAuthorizedError, with: :forbidden
     rescue_from ActionController::ParameterMissing, with: :client_error

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,38 @@
+module Api
+  module V1
+    class UsersController < ApiController
+      include Shared::Users
+
+      skip_before_action :validate_auth_scheme, only: %i(index show)
+      skip_before_action :authenticate_client, only: %i(index show)
+
+      def create
+        @user = User.new(user_password_params)
+        authorize @user
+
+        if @user.save
+          render_json_api present_entity(@user)
+        else
+          render_json_api present_errors(@user, [@user.errors]), status: 400
+        end
+      end
+
+      def update
+        shared_update(lambda do
+          render_json_api present_entity(@user)
+        end, lambda do
+          render_json_api present_errors(@user, [@user.errors]), status: 400
+        end)
+      end
+
+      private
+
+      def user_password_params
+        params.require(:data).
+          require(:attributes).
+          permit(:first_name, :last_name, :email, :bio,
+                 :current_password, :password, :password_confirmation)
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -18,6 +18,8 @@ module Api
       end
 
       def update
+        @user = User.find(params[:id])
+
         shared_update(lambda do
           render_json_api present_entity(@user)
         end, lambda do

--- a/app/controllers/concerns/shared/users.rb
+++ b/app/controllers/concerns/shared/users.rb
@@ -1,0 +1,28 @@
+module Shared
+  module Users
+    def shared_update(success, failure)
+      @user = User.find(current_user.id)
+      authorize @user
+
+      if skip_password_update?
+        user_params = user_password_params.except(:current_password,
+                                                  :password,
+                                                  :password_confirmation)
+      end
+
+      if user_params ? @user.update(user_params) : @user.update_with_password(user_password_params)
+        success.call
+      else
+        failure.call
+      end
+    end
+
+    private
+
+    def skip_password_update?
+      user_password_params[:current_password].blank? &&
+        user_password_params[:password].blank? &&
+        user_password_params[:password_confirmation].blank?
+    end
+  end
+end

--- a/app/controllers/concerns/shared/users.rb
+++ b/app/controllers/concerns/shared/users.rb
@@ -1,7 +1,6 @@
 module Shared
   module Users
     def shared_update(success, failure)
-      @user = User.find(current_user.id)
       authorize @user
 
       if skip_password_update?

--- a/app/controllers/users/profile_controller.rb
+++ b/app/controllers/users/profile_controller.rb
@@ -1,5 +1,7 @@
 module Users
   class ProfileController < ApplicationController
+    include Shared::Users
+
     before_action :authenticate_user!
 
     def edit
@@ -7,20 +9,12 @@ module Users
     end
 
     def update
-      @user = User.find(current_user.id)
-
-      if skip_password_update?
-        user_params = user_password_params.except(:current_password,
-                                                  :password,
-                                                  :password_confirmation)
-      end
-
-      if user_params ? @user.update(user_params) : @user.update_with_password(user_password_params)
+      shared_update(lambda do
         bypass_sign_in(@user)
         redirect_to profile_path, notice: 'Profile updated.'
-      else
+      end, lambda do
         render :edit
-      end
+      end)
     end
 
     private

--- a/app/controllers/users/profile_controller.rb
+++ b/app/controllers/users/profile_controller.rb
@@ -9,6 +9,8 @@ module Users
     end
 
     def update
+      @user = User.find(current_user.id)
+
       shared_update(lambda do
         bypass_sign_in(@user)
         redirect_to profile_path, notice: 'Profile updated.'

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,0 +1,36 @@
+class UserPolicy < ApplicationPolicy
+  attr_reader :current_user, :user
+
+  def initialize(current_user, user)
+    @current_user = current_user
+    @user = user
+  end
+
+  def index?
+    @current_user
+  end
+
+  def show?
+    @current_user == @user
+  end
+
+  def create?
+    @current_user
+  end
+
+  def new?
+    @current_user
+  end
+
+  def update?
+    @current_user == @user
+  end
+
+  def edit?
+    @current_user == @user
+  end
+
+  def destroy?
+    @current_user == @user
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/search', to: 'search#show', as: 'search'
+      resources :users, only: %i(create update)
       resources :resources, only: %i(show create update)
       resources :groups, only: %i(index show create update) do
         namespace :relationships do

--- a/spec/requests/api/v1/users_controller_spec.rb
+++ b/spec/requests/api/v1/users_controller_spec.rb
@@ -1,0 +1,166 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::UsersController, type: :request do
+  let(:user) { create(:user, email: 'pat@example.com') }
+  let(:api_key) { user.api_keys.create! }
+  let(:headers) do
+    {
+      'Content-Type' => 'application/vnd.api+json',
+      'Accept' => 'application/vnd.api+json',
+      'Authorization' => "GC #{api_key.access_key}:#{api_key.secret_key}"
+    }
+  end
+
+  describe 'POST /api/v1/users' do
+    context 'authenticated' do
+      context 'with valid params' do
+        before do
+          post '/api/v1/users', params: {
+            data: {
+              type: 'users',
+              attributes: {
+                email: 'john@example.com',
+                first_name: 'John',
+                last_name: 'Doe',
+                password: 'password',
+                password_confirmation: 'password'
+              }
+            }
+          }.to_json, headers: headers
+        end
+
+        it 'returns 200 OK' do
+          expect(response.status).to eq 200
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+
+        it 'returns the user as JSON API' do
+          expect(response).to match_response_schema('jsonapi')
+          expect(json_body['data']['id']).to eq User.last.id.to_s
+        end
+
+        it 'creates the user' do
+          expect(User.count).to eq 2
+        end
+      end
+
+      context 'with invalid params' do
+        before do
+          post '/api/v1/users', params: {
+            data: {
+              type: 'users',
+              attributes: {
+                email: nil
+              }
+            }
+          }.to_json, headers: headers
+        end
+
+        it 'returns 400 OK' do
+          expect(response.status).to eq 400
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+
+        it 'creates the user' do
+          expect(User.count).to eq 1
+        end
+      end
+    end
+
+    context 'unauthenticated' do
+      before do
+        post '/api/v1/users', params: {
+          data: {
+            type: 'users',
+            attributes: {
+              email: 'john@example.com',
+              first_name: 'John',
+              last_name: 'Doe',
+              password: 'password',
+              password_confirmation: 'password'
+            }
+          }
+        }.to_json, headers: {
+          'Authorization' => 'GC 123:123'
+        }
+      end
+
+      it 'returns 401 OK' do
+        expect(response.status).to eq 401
+      end
+    end
+  end
+
+  describe 'PATCH /api/v1/users/:id' do
+    context 'authenticated' do
+      context 'with valid params' do
+        before do
+          patch "/api/v1/users/#{user.id}", params: {
+            data: {
+              type: 'users',
+              attributes: {
+                first_name: 'Alice'
+              }
+            }
+          }.to_json, headers: headers
+        end
+
+        it 'returns 200 OK' do
+          expect(response.status).to eq 200
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+
+        it 'returns the user as JSON API' do
+          expect(response).to match_response_schema('jsonapi')
+          expect(json_body['data']['id']).to eq User.last.id.to_s
+          expect(json_body['data']['attributes']['first_name']).to eq 'Alice'
+        end
+
+        it 'updates the user' do
+          expect(User.last.first_name).to eq 'Alice'
+        end
+      end
+
+      context 'with invalid params' do
+        before do
+          patch "/api/v1/users/#{user.id}", params: {
+            data: {
+              type: 'users',
+              attributes: {
+                email: nil
+              }
+            }
+          }.to_json, headers: headers
+        end
+
+        it 'returns 400 OK' do
+          expect(response.status).to eq 400
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+
+        it 'does not update the user' do
+          expect(User.last.email).to eq 'pat@example.com'
+        end
+      end
+    end
+
+    context 'unauthenticated' do
+      before do
+        patch "/api/v1/users/#{user.id}", params: {
+          data: {
+            type: 'users',
+            attributes: {
+              first_name: 'Alice'
+            }
+          }
+        }.to_json, headers: {
+          'Authorization' => 'GC 123:123'
+        }
+      end
+
+      it 'returns 401 OK' do
+        expect(response.status).to eq 401
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Reason for change

GC requested new resources to be added to the web API.

# Changes

- Add endpoints to create and update users

# Note

I'm not sure how we want to handle file uploads through the API so I haven't implemented anything yet. If we want to stick with the JSON API spec, the files should probably be base64 encoded and sent as part of the JSON. 

There are two other options though:

- Use a different mime-type (like a regular `multipart/form-data`) for endpoints where files can be sent (user creation, resource creation) that can receive both text parameters and files.
- Separate the file creation from the resource creation by creating a separate endpoint that only deals with receiving files and associating with the resources.