### PR TITLE
Fix lists not showing up correctly on group page

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,7 +8,7 @@ class GroupsController < ApplicationController
 
   def show
     @resources = @group.latest_resources
-    @lists = @group.lists
+    @lists = @group.owned_lists.order(created_at: :desc)
     @similar = Suggesters::Tags.new(tags: @group.cached_tags,
                                     except: @group,
                                     limit: 12,

--- a/app/views/shared/summary_cards/_group.html.slim
+++ b/app/views/shared/summary_cards/_group.html.slim
@@ -1,4 +1,4 @@
-.summary-card 
+.summary-card
   .summary-card__body
     - if remove
       a.summary-card__delete href='' data-sc-remove="#{remove}"
@@ -21,8 +21,8 @@
       = render 'shared/components/tags_list', tags: resource.cached_tags
       .summary-card__row.summary-card__row--last
         .summary-card__more.summary-card__more--space.summary-card__more--buttons
-          = react_component 'AddToListButton', { name: resource.name, 
-                                                 id: resource.id, 
+          = react_component 'AddToListButton', { name: resource.name,
+                                                 id: resource.id,
                                                  type: 'Group',
                                                  action: list_items_path,
                                                  loader_image: image_path('loader.gif'),
@@ -35,13 +35,13 @@
         .summary-card__more.summary-card__more--meta
           .summary-card__metadata.summary-card__metadata--last
             i.fa.fa-th-list.glyphicon--right
-            | #{resource.lists.count} Lists
+            | #{resource.owned_lists.count} Lists
           .summary-card__metadata
             i.fa.fa-users.glyphicon--right
-            | #{resource.users.count} members   
+            | #{resource.users.count} members
           .summary-card__metadata
             i.fa.fa-comments.glyphicon--right
-            span.disqus-comment-count data-disqus-identifier="#{url_for(resource)}" 
+            span.disqus-comment-count data-disqus-identifier="#{url_for(resource)}"
               | 0 Comments
         .clearfix
-    
+


### PR DESCRIPTION
# Reason for change

Currently, the group page isn't displaying the lists owned by the group. Instead, it shows the lists to which a group has been added.

# Change

This PR changes the logic to display the lists owned by the group being viewed instead of the lists to which the group belongs.