### PR TITLE
Remove content from resources

### DIFF
--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -38,8 +38,8 @@ class Resource < ApplicationRecord
   end
 
   def excerpt
-    return content unless content.is_a?(String)
-    content.truncate(500)
+    return short_content unless short_content.is_a?(String)
+    short_content.truncate(500)
   end
 
   def creators

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -25,10 +25,10 @@
         - if resource.url?
           = link_to resource.url, resource.url, target: '_blank'
         - else
-          - if resource.content.is_a?(String)
-            = resource.content.truncate(400)
+          - if resource.short_content.is_a?(String)
+            = resource.short_content.truncate(400)
           - else
-            = resource.content
+            = resource.short_content
     - unless minimalist
       = render 'shared/components/tags_list', tags: resource.cached_tags
       .summary-card__row.summary-card__row--last

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require './lib/middleware/catch_json_parse_errors.rb'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -17,4 +18,5 @@ end
 
 Rails.application.configure do
   config.autoload_paths << Rails.root.join('lib')
+  config.middleware.insert_before Rack::Head, CatchJsonParseErrors
 end

--- a/db/migrate/20170615070755_remove_content_from_resources.rb
+++ b/db/migrate/20170615070755_remove_content_from_resources.rb
@@ -1,0 +1,5 @@
+class RemoveContentFromResources < ActiveRecord::Migration[5.0]
+  def change
+    remove_column :resources, :content, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170615024650) do
+ActiveRecord::Schema.define(version: 20170615070755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,7 +81,6 @@ ActiveRecord::Schema.define(version: 20170615024650) do
     t.datetime "created_at",                 null: false
     t.datetime "updated_at",                 null: false
     t.jsonb    "metadata",      default: {}, null: false
-    t.jsonb    "content",       default: {}, null: false
     t.text     "cached_tags",   default: [],              array: true
     t.integer  "privacy",       default: 0,  null: false
     t.string   "url"

--- a/lib/etl/transform/transform_epub.rb
+++ b/lib/etl/transform/transform_epub.rb
@@ -7,7 +7,7 @@ class TransformEpub
 
     {
       title: title,
-      content: PageContentExtractor.new(parsed_book).start,
+      long_content: PageContentExtractor.new(parsed_book).start,
       metadata: {
         creators: creators,
         date: date,

--- a/lib/middleware/catch_json_parse_errors.rb
+++ b/lib/middleware/catch_json_parse_errors.rb
@@ -1,0 +1,25 @@
+class CatchJsonParseErrors
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env)
+  rescue ActionDispatch::ParamsParser::ParseError => error
+    if env['CONTENT_TYPE'] =~ %r(application\/vnd\.api\+json)
+      error_output = "There was a problem in the JSON you submitted: #{error.class}"
+      return [
+        400, { 'Content-Type' => 'application/vnd.api+json' },
+        [{ status: 400, errors: [
+          {
+            status: 400,
+            title: error.class,
+            details: error_output
+          }
+        ] }.to_json]
+      ]
+    else
+      raise error
+    end
+  end
+end

--- a/lib/tasks/resources.rake
+++ b/lib/tasks/resources.rake
@@ -2,7 +2,7 @@ namespace :resources do
   desc 'Format content and metadata dates for elasticsearch'
   task clean_resources: :environment do
     Resource.all.each do |resource|
-      resource.content = '' unless resource.content.is_a?(String)
+      resource.short_content = '' unless resource.short_content.is_a?(String)
 
       if resource.metadata['date'] == '' || resource.metadata['date'].blank?
         resource.metadata['date'] = nil
@@ -24,9 +24,9 @@ namespace :resources do
   task transfer_content: :environment do
     Resource.find_each.each do |resource|
       ap "Transferring content for resource #{resource.id}"
-      next unless resource.content.is_a?(String)
-      resource.long_content = resource.content
-      resource.content = {}
+      next unless resource.short_content.is_a?(String)
+      resource.long_content = resource.short_content
+      resource.short_content = {}
       resource.save!
     end
   end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -2,7 +2,7 @@ FactoryGirl.define do
   factory :resource do
     title { Faker::Book.title }
     resource_type { :book }
-    content { Faker::Hipster.paragraph }
+    short_content { Faker::Hipster.paragraph }
     privacy 'publ'
   end
 end

--- a/spec/requests/api/v1/networks_controller_spec.rb
+++ b/spec/requests/api/v1/networks_controller_spec.rb
@@ -49,6 +49,46 @@ RSpec.describe Api::V1::NetworksController, type: :request do
 
   describe 'POST /api/v1/networks' do
     context 'authenticated' do
+      context 'with invalid content type' do
+        it 'returns 400 OK' do
+          post '/api/v1/networks', params: '{"test":"a"}', headers: {
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/vnd.api+json',
+            'Authorization' => "GC #{api_key.access_key}:#{api_key.secret_key}"
+          }
+
+          expect(response.status).to eq 415
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+      end
+
+      context 'with invalid json' do
+        it 'returns 400 OK' do
+          post '/api/v1/networks', params: '{"test":"a"', headers: headers
+
+          expect(response.status).to eq 400
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+      end
+
+      context 'with empty params' do
+        it 'returns 400 OK' do
+          post '/api/v1/networks', params: '{}', headers: headers
+
+          expect(response.status).to eq 400
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+      end
+
+      context 'with empty data params' do
+        it 'returns 400 OK' do
+          post '/api/v1/networks', params: '{"data": {}}', headers: headers
+
+          expect(response.status).to eq 400
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+      end
+
       context 'with valid params' do
         before do
           post '/api/v1/networks', params: {


### PR DESCRIPTION
# Reason for changes

Resources now have `short_content` and `long_content` instead of `content` which should be removed.

# Changes

- Remove `content` from `resources`
- Replace all occurrences of `content` in the code