### PR TITLE
Fix 500 API errors (malformed JSON & Invalid params)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -1,6 +1,7 @@
 require_relative 'boot'
 
 require 'rails/all'
+require './lib/middleware/catch_json_parse_errors.rb'
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
@@ -17,4 +18,5 @@ end
 
 Rails.application.configure do
   config.autoload_paths << Rails.root.join('lib')
+  config.middleware.insert_before Rack::Head, CatchJsonParseErrors
 end

--- a/lib/middleware/catch_json_parse_errors.rb
+++ b/lib/middleware/catch_json_parse_errors.rb
@@ -1,0 +1,25 @@
+class CatchJsonParseErrors
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    @app.call(env)
+  rescue ActionDispatch::ParamsParser::ParseError => error
+    if env['CONTENT_TYPE'] =~ %r(application\/vnd\.api\+json)
+      error_output = "There was a problem in the JSON you submitted: #{error.class}"
+      return [
+        400, { 'Content-Type' => 'application/vnd.api+json' },
+        [{ status: 400, errors: [
+          {
+            status: 400,
+            title: error.class,
+            details: error_output
+          }
+        ] }.to_json]
+      ]
+    else
+      raise error
+    end
+  end
+end

--- a/spec/requests/api/v1/networks_controller_spec.rb
+++ b/spec/requests/api/v1/networks_controller_spec.rb
@@ -49,6 +49,46 @@ RSpec.describe Api::V1::NetworksController, type: :request do
 
   describe 'POST /api/v1/networks' do
     context 'authenticated' do
+      context 'with invalid content type' do
+        it 'returns 400 OK' do
+          post '/api/v1/networks', params: '{"test":"a"}', headers: {
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/vnd.api+json',
+            'Authorization' => "GC #{api_key.access_key}:#{api_key.secret_key}"
+          }
+
+          expect(response.status).to eq 415
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+      end
+
+      context 'with invalid json' do
+        it 'returns 400 OK' do
+          post '/api/v1/networks', params: '{"test":"a"', headers: headers
+
+          expect(response.status).to eq 400
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+      end
+
+      context 'with empty params' do
+        it 'returns 400 OK' do
+          post '/api/v1/networks', params: '{}', headers: headers
+
+          expect(response.status).to eq 400
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+      end
+
+      context 'with empty data params' do
+        it 'returns 400 OK' do
+          post '/api/v1/networks', params: '{"data": {}}', headers: headers
+
+          expect(response.status).to eq 400
+          expect(response.content_type).to eq 'application/vnd.api+json'
+        end
+      end
+
       context 'with valid params' do
         before do
           post '/api/v1/networks', params: {


### PR DESCRIPTION
# Reason for change

Currently, sending a malformed JSON or invalid parameters is returning a 500 error. The server should return 400 instead since the client is sending incorrect requests.

# Changes

- Catch JSON parsing errors
- Add tests checking that the API is behaving as expected