### PR TITLE
Set resources imported through ETL to public

### DIFF
--- a/lib/etl/load/create_new_resource_record.rb
+++ b/lib/etl/load/create_new_resource_record.rb
@@ -12,6 +12,7 @@ class CreateNewResourceRecord < CreateNewRecord
   def create
     tags = attributes.delete(:tags) if attributes[:tags]
     attributes[:url] = attributes.delete(:content_url)
+    attributes[:privacy] = :publ
     record = Resource.create!(attributes)
 
     if tags && tags.any?

--- a/spec/etl/local_json_resources_to_db_spec.rb
+++ b/spec/etl/local_json_resources_to_db_spec.rb
@@ -5,5 +5,6 @@ RSpec.describe 'local_json_resources_to_db' do
   it 'extracts the valid JSON documents and generates resources' do
     ETL.run('lib/etl/local_json_resources_to_db.etl')
     expect(Resource.count).to eq 2
+    expect(Resource.first.privacy).to eq 'publ'
   end
 end


### PR DESCRIPTION
# Reason for change

By default, resources are created as private so all resources uploaded by users will be private by default. This means we need to update the ETL resource load class to set the resources as public.

# Changes

- Set the privacy of loaded resources to public
- Ensure the loaded resources are set to public correctly

# Note

I've started running a script to update the privacy of all the resources that were imported.