### PR TITLE
Resources that contain URLs should show the "view original" link

### DIFF
--- a/app/assets/stylesheets/components/_summary-card.scss
+++ b/app/assets/stylesheets/components/_summary-card.scss
@@ -112,6 +112,11 @@
     float: left;
   }
 
+
+  &__more--mr {
+    margin-right: 10px;
+  }
+
   &__more--space {
     margin-right: 5%;
   }
@@ -123,6 +128,7 @@
   &__more--meta {
     width: 65%;
     min-width: 300px;
+    float: right;
   }
 
   &__actions {

--- a/app/assets/stylesheets/helpers/_buttons.scss
+++ b/app/assets/stylesheets/helpers/_buttons.scss
@@ -80,8 +80,8 @@
   .btn-#{$name}.disabled.active,
   .btn-#{$name}[disabled].active,
   fieldset[disabled] .btn-#{$name}.active {
-    background-color: #EF5350;
-    border-color: #EF5350;
+    background-color: $dark;
+    border-color: $dark;
   }
 
   .btn-#{$name} .badge {

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -33,7 +33,7 @@
     - unless minimalist
       = render 'shared/components/tags_list', tags: resource.cached_tags
       .summary-card__row.summary-card__row--last
-        .summary-card__more.summary-card__more--space.summary-card__more--buttons
+        .summary-card__more.summary-card__more--mr
           = react_component 'AddToListButton', { name: resource.name,
                                                  id: resource.id,
                                                  type: 'Resource',
@@ -45,12 +45,17 @@
                                                  button_class: "btn-gc",
                                                  logged_in: current_user.present?,
                                                  options: current_user ? owner_options(current_user, resource) : [] }
-        .summary-card__more.summary-card__more--meta
-          .summary-card__metadata.summary-card__metadata--last
-            i.fa.fa-pencil.glyphicon--right
-            | 102 Annotations
-          .summary-card__metadata
-            i.fa.fa-comments.glyphicon--right
-            span.disqus-comment-count data-disqus-identifier="#{url_for(resource)}"
-              | 0 Comments
-        .clearfix
+        .summary-card__more
+          - if resource.url
+            = link_to via_hypothesis(resource.url), target: '_blank', class: 'resource-actions__button btn btn-dark-blue'
+              | View Original
+              i.fa.fa-link.glyphicon--left
+      .summary-card__more.summary-card__more--meta
+        .summary-card__metadata.summary-card__metadata--last
+          i.fa.fa-pencil.glyphicon--right
+          | 102 Annotations
+        .summary-card__metadata
+          i.fa.fa-comments.glyphicon--right
+          span.disqus-comment-count data-disqus-identifier="#{url_for(resource)}"
+            | 0 Comments
+      .clearfix


### PR DESCRIPTION
Depends on PR #175.

# Reason for change

Currently, the summary cards for resources don't show the link to the original URL.

# Changes

- Add button linking to original URL through hypothesis in resource summary cards.