### PR TITLE
Add new fields for search

### DIFF
--- a/app/services/search_builders/query.rb
+++ b/app/services/search_builders/query.rb
@@ -1,5 +1,17 @@
 module SearchBuilders
   class Query
+    QUERY_KEYS = %i{
+      title
+      name
+      short_content
+      long_content
+      short_description
+      long_description
+      metadata.publisher
+      metadata.creators
+      metadata.isbn
+    }.freeze
+
     def initialize(query, es_params)
       @query = query
       @es_params = es_params
@@ -8,10 +20,9 @@ module SearchBuilders
     def build
       return @es_params if @query.blank?
 
-      @es_params[:query][:bool][:must][:bool][:should] << { match: { title: @query } }
-      @es_params[:query][:bool][:must][:bool][:should] << { match: { name: @query } }
-      @es_params[:query][:bool][:must][:bool][:should] << { match: { content: @query } }
-      @es_params[:query][:bool][:must][:bool][:should] << { match: { long_description: @query } }
+      QUERY_KEYS.each do |key|
+        @es_params[:query][:bool][:must][:bool][:should] << { match: { key => @query } }
+      end
 
       @es_params
     end

--- a/app/views/search/_results.html.slim
+++ b/app/views/search/_results.html.slim
@@ -6,14 +6,16 @@
           h6
             span= "Results for \"#{@query}\" "
             span.gray-light
-              | &bull;
+              = ' '
+              |  &bull;
+              = ' '
               = " #{number_with_delimiter(@total_count, delimiter: ',')}"
         .col-xs-12.col-sm-2.col-sm-offset-4
           = hidden_field_tag :query, @query
-          = select_tag :sort, 
-                       options_for_select([ ['Score', 'score'], 
-                                            ['Newest First', '-published_at'], 
-                                            ['Oldest First', 'published_at'] ], @sort || 'SCORE'), 
+          = select_tag :sort,
+                       options_for_select([ ['Score', 'score'],
+                                            ['Newest First', '-published_at'],
+                                            ['Oldest First', 'published_at'] ], @sort || 'SCORE'),
                        class: 'form-control gc-select',
                        data: { 'filter-select' => true }
   - if @results.any?

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -12,10 +12,14 @@
         h6
           - if resource.creators.present?
             = resource.creators
+            = ' '
             |  &bull;
+            = ' '
           - if resource.publisher
             = resource.publisher
+            = ' '
             |  &bull;
+            = ' '
           = humanize_date(resource.published_at)
       - if defined?(hit) && hit
         .summary-card__relevancy style="background-color: rgba(95, 125, 140, #{score_opacity(hit._score)});"


### PR DESCRIPTION
# Reason for change

We thought there was something wrong with the indexing of the metadata for resources. After checking it, I realized that the issue was not in the indexing but in the way we search for the resources. In our implementation, we need to specify each field in which we want to search.

# Changes

I added the metadata publisher, creators and isbn fields and fixed the content/description fields. Let me know if we need to search in more fields.