### PR TITLE
Use short/long content appropriately

### DIFF
--- a/app/views/networks/show.html.slim
+++ b/app/views/networks/show.html.slim
@@ -65,7 +65,7 @@
                   .col-xs-12
                     p.page-details__description
                       - if @network.short_description
-                        = @network.short_description.truncate(400)
+                        = @network.short_description
                       - else
                         = @network.long_description&.truncate(400)
                   .clearfix

--- a/app/views/networks/show.html.slim
+++ b/app/views/networks/show.html.slim
@@ -64,7 +64,10 @@
                 .page-details__row
                   .col-xs-12
                     p.page-details__description
-                      = @network.long_description
+                      - if @network.short_description
+                        = @network.short_description.truncate(400)
+                      - else
+                        = @network.long_description&.truncate(400)
                   .clearfix
 
               .row

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -64,10 +64,10 @@
                 .page-details__row
                   .col-xs-12
                     p.page-details__description
-                      - if @resource.url?
-                        = @resource.url
+                      - if @resource.short_content
+                        = @resource.short_content.truncate(400)
                       - else
-                        = @resource.excerpt
+                        = @resource.long_content&.truncate(400)
                   .clearfix
 
               .row

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -65,7 +65,7 @@
                   .col-xs-12
                     p.page-details__description
                       - if @resource.short_content
-                        = @resource.short_content.truncate(400)
+                        = @resource.short_content
                       - else
                         = @resource.long_content&.truncate(400)
                   .clearfix

--- a/app/views/shared/summary_cards/_network.html.slim
+++ b/app/views/shared/summary_cards/_network.html.slim
@@ -24,7 +24,11 @@
       .clearfix
     .summary-card__row
       p
-        = resource.short_description
+        - if resource.short_description
+          = resource.short_description.truncate(400)
+        - else
+          = resource.long_description&.truncate(400)
+
     - unless minimalist
       = render 'shared/components/tags_list', tags: resource.cached_tags
       .summary-card__row.summary-card__row--last

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -27,13 +27,11 @@
       .clearfix
     .summary-card__row
       p
-        - if resource.url?
-          = link_to resource.url, resource.url, target: '_blank'
+        - if resource.short_content
+          = resource.short_content.truncate(400)
         - else
-          - if resource.short_content.is_a?(String)
-            = resource.short_content.truncate(400)
-          - else
-            = resource.short_content
+          = resource.long_content&.truncate(400)
+
     - unless minimalist
       = render 'shared/components/tags_list', tags: resource.cached_tags
       .summary-card__row.summary-card__row--last

--- a/spec/feature/user_manages_networks_spec.rb
+++ b/spec/feature/user_manages_networks_spec.rb
@@ -34,7 +34,7 @@ RSpec.feature 'Managing networks' do
 
     within("#edit_network_#{network.id}") do
       fill_in 'network[name]', with: network.name
-      fill_in 'network[long_description]', with: 'New Description.'
+      fill_in 'network[short_description]', with: 'New Description.'
       find('.bootstrap-tagsinput').find('input').set('some,tags')
 
       click_on 'Update'

--- a/spec/feature/user_manages_resources_spec.rb
+++ b/spec/feature/user_manages_resources_spec.rb
@@ -20,7 +20,7 @@ RSpec.feature 'Managing resources' do
     click_link resource.title
 
     expect(page).to have_text('Urls')
-    expect(page).to have_text('http://example.com')
+    expect(page).to have_text('View Original')
   end
 
   scenario 'users can create a resource' do


### PR DESCRIPTION
# Reason for change

If no short content is available, we should show the truncated long content.

# Changes

- Use `short_content` if available, else truncate `long_content`