### PR TITLE
Memory Improvements for home and search pages

### DIFF
--- a/app/controllers/api/v1/relationships/items_controller.rb
+++ b/app/controllers/api/v1/relationships/items_controller.rb
@@ -10,7 +10,7 @@ module Api
         def index
           results = @list.lists_items.includes(:item).
                     page(params[:page] || 1).per(params[:per] || 10)
-          render_json_api present_collection(results, @list.lists_items.count)
+          render_json_api present_collection(results, @list.lists_items_count)
         end
 
         def create
@@ -24,7 +24,7 @@ module Api
 
           results = @list.lists_items.includes(:item).
                     page(params[:page] || 1).per(params[:per] || 10)
-          render_json_api present_collection(results, @list.lists_items.count)
+          render_json_api present_collection(results, @list.lists_items_count)
         end
 
         def update
@@ -50,7 +50,7 @@ module Api
 
           results = @list.lists_items.includes(:item).
                     page(params[:page] || 1).per(params[:per] || 10)
-          render_json_api present_collection(results, @list.lists_items.count)
+          render_json_api present_collection(results, @list.lists_items_count)
         end
 
         private

--- a/app/controllers/list_items_controller.rb
+++ b/app/controllers/list_items_controller.rb
@@ -14,7 +14,7 @@ class ListItemsController < ApplicationController
             status: 'ok',
             list_name: list.name,
             resource_name: item.name,
-            list_count: item.lists.count
+            list_count: item.lists_items_count
           }
         else
           render_errors(list_item.errors)
@@ -71,7 +71,7 @@ class ListItemsController < ApplicationController
       status: 'ko',
       list_name: list.name,
       resource_name: item.name,
-      list_count: item.lists.count,
+      list_count: item.lists_items_count,
       errors: errors
     }
   end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -1,7 +1,9 @@
 class StaticPagesController < ApplicationController
   layout false, only: :home
 
-  def home; end
+  def home
+    @counts = Resource.group(:resource_type).count
+  end
 
   def policy; end
 

--- a/app/models/lists_item.rb
+++ b/app/models/lists_item.rb
@@ -1,6 +1,6 @@
 class ListsItem < ApplicationRecord
-  belongs_to :list
-  belongs_to :item, polymorphic: true
+  belongs_to :list, counter_cache: true
+  belongs_to :item, polymorphic: true, counter_cache: true
 
   validates :list, presence: true
   validates :item, presence: true

--- a/app/models/networks_user.rb
+++ b/app/models/networks_user.rb
@@ -1,5 +1,5 @@
 class NetworksUser < ApplicationRecord
-  belongs_to :network
+  belongs_to :network, counter_cache: true
   belongs_to :user
 
   validates :network, presence: true

--- a/app/presenters/v1/network_presenter.rb
+++ b/app/presenters/v1/network_presenter.rb
@@ -16,7 +16,7 @@ module V1
     end
 
     def lists_count
-      object.lists.count
+      object.lists_items_count
     end
 
     def resources_count

--- a/app/views/lists/_items.html.slim
+++ b/app/views/lists/_items.html.slim
@@ -3,7 +3,7 @@
     .col-xs-12
       .page-details__section-title.page-details__row
         h6.pull-left
-          | #{@list.lists_items.count} items
+          | #{@list.lists_items_count} items
         .pull-right
           .pull-left.resource-actions__button--right
             = select_tag :sort, 

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -41,7 +41,7 @@
                         = image_tag(@network.users[1] ? @network.users[1].avatar_url : 'user.png',
                                     class: 'user-picture__image user-picture__image--realign user-picture__image--over')
                         a class='btn btn--picture-cover'
-                          = @network.users.count
+                          = @network.networks_users_count
                     .page-details__metadata
                       | members
                     .page-details__metadata

--- a/app/views/networks/show.html.slim
+++ b/app/views/networks/show.html.slim
@@ -53,7 +53,7 @@
                         = image_tag(@network.users[1] ? @network.users[1].avatar_url : 'user.png',
                                     class: 'user-picture__image user-picture__image--over user-picture__image--realign')
                         = link_to network_members_path(@network), class: 'btn btn--picture-cover' do
-                          = @network.users.count
+                          = @network.networks_users_count
                     .page-details__metadata
                       | members
                     .page-details__metadata

--- a/app/views/networks/show.html.slim
+++ b/app/views/networks/show.html.slim
@@ -85,7 +85,7 @@
                                                            loader_image: image_path('loader.gif'),
                                                            autocomplete_path: autocomplete_lists_path(current_resource: "Network:#{@network.id}"),
                                                            authenticity_token: form_authenticity_token,
-                                                           list_count: @network.lists.count,
+                                                           list_count: @network.lists_items_count,
                                                            button_class: "btn-networks btn--large",
                                                            logged_in: current_user.present?,
                                                            options: current_user ? owner_options(current_user, @network) : [] }

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -85,7 +85,7 @@
                                                            loader_image: image_path('loader.gif'),
                                                            autocomplete_path: autocomplete_lists_path(current_resource: "Resource:#{@resource.id}"),
                                                            authenticity_token: form_authenticity_token,
-                                                           list_count: @resource.lists.count,
+                                                           list_count: @resource.lists_items_count,
                                                            button_class: "btn-#{@resource.resource_type} btn--large",
                                                            logged_in: current_user.present?,
                                                            options: current_user ? owner_options(current_user, @resource) : [] }

--- a/app/views/shared/summary_cards/_list.html.slim
+++ b/app/views/shared/summary_cards/_list.html.slim
@@ -31,5 +31,5 @@
     .summary-card__row.summary-card__row--last
       .summary-card__metadata.summary-card__metadata--left
         i.fa.fa-file-text.glyphicon--right
-        = "#{resource.lists_items.count} items"
+        = "#{resource.lists_items_count} items"
       .clearfix

--- a/app/views/shared/summary_cards/_network.html.slim
+++ b/app/views/shared/summary_cards/_network.html.slim
@@ -50,7 +50,7 @@
             | #{resource.owned_lists.count} Lists
           .summary-card__metadata
             i.fa.fa-users.glyphicon--right
-            | #{resource.users.count} members
+            | #{resource.networks_users_count} members
           .summary-card__metadata
             i.fa.fa-comments.glyphicon--right
             span.disqus-comment-count data-disqus-identifier="#{url_for(resource)}"

--- a/app/views/shared/summary_cards/_network.html.slim
+++ b/app/views/shared/summary_cards/_network.html.slim
@@ -40,7 +40,7 @@
                                                  loader_image: image_path('loader.gif'),
                                                  autocomplete_path: autocomplete_lists_path(current_resource: "Network:#{resource.id}"),
                                                  authenticity_token: form_authenticity_token,
-                                                 list_count: resource.lists.count,
+                                                 list_count: resource.lists_items_count,
                                                  button_class: "btn-gc",
                                                  logged_in: current_user.present?,
                                                  options: current_user ? owner_options(current_user, resource) : [] }

--- a/app/views/shared/summary_cards/_resource.html.slim
+++ b/app/views/shared/summary_cards/_resource.html.slim
@@ -43,7 +43,7 @@
                                                  loader_image: image_path('loader.gif'),
                                                  autocomplete_path: autocomplete_lists_path(current_resource: "Resource:#{resource.id}"),
                                                  authenticity_token: form_authenticity_token,
-                                                 list_count: resource.lists.count,
+                                                 list_count: resource.lists_items_count,
                                                  button_class: "btn-gc",
                                                  logged_in: current_user.present?,
                                                  options: current_user ? owner_options(current_user, resource) : [] }

--- a/app/views/shared/summary_cards/mini/_network.html.slim
+++ b/app/views/shared/summary_cards/mini/_network.html.slim
@@ -15,7 +15,7 @@
                       class: 'user-picture__image user-picture__image--mini user-picture__image--mini-over')
           .clearfix
       .summary-card__metadata.summary-card__metadata--left.summary-card__metadata--mini
-        p.summary-card__p--mini= "+#{network.users.count > 3 ? network.users.count - 3 : 0}"
+        p.summary-card__p--mini= "+#{network.networks_users_count > 3 ? network.networks_users_count - 3 : 0}"
       .summary-card__metadata.summary-card__metadata--left.summary-card__metadata--mini
         p.summary-card__p--mini
           i.fa.fa-calendar.glyphicon--right

--- a/app/views/static_pages/_connect.html.slim
+++ b/app/views/static_pages/_connect.html.slim
@@ -26,7 +26,7 @@
               #carousel-connect.carousel.slide data-ride="carousel"
                 .row
                   .carousel-inner.home-connect__feature-carousel role="listbox"
-                    - Network.limit(9).each_with_index do |network, index|
+                    - Network.includes(:users).limit(9).each_with_index do |network, index|
                       div class="#{index == 0 ? 'item active' : 'item'}"
                         .col-xs-12
                           = render 'shared/summary_cards/mini/network', network: network

--- a/app/views/static_pages/_content.html.slim
+++ b/app/views/static_pages/_content.html.slim
@@ -14,43 +14,43 @@
                   .row
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Collected Books',
-                                                                     count: Resource.books.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:book]],
                                                                      list: Resource.books.limit(6)
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Written Articles',
-                                                                     count: Resource.articles.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:article]],
                                                                      list: Resource.articles.limit(6)
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Issued Reports',
-                                                                     count: Resource.reports.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:report]],
                                                                      list: Resource.reports.limit(6)
                 .item
                   .row
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Recorded Audios',
-                                                                     count: Resource.audios.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:audio]],
                                                                      list: Resource.audios.limit(6)
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Collected Courses',
-                                                                     count: Resource.courses.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:course]],
                                                                      list: Resource.courses.limit(6)
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Collected Datasets',
-                                                                     count: Resource.datasets.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:dataset]],
                                                                      list: Resource.datasets.limit(6)
                 .item
                   .row
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Collected Syllabuses',
-                                                                     count: Resource.syllabuses.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:syllabus]],
                                                                      list: Resource.syllabuses.limit(6)
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Collected Videos',
-                                                                     count: Resource.videos.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:video]],
                                                                      list: Resource.videos.limit(6)
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Collected Profiles',
-                                                                     count: Resource.profiles.count,
+                                                                     count: @counts[Resource::RESOURCE_TYPES[:profile]],
                                                                      list: Resource.profiles.limit(6)
           .row
             .col-xs-12.col-md-8.col-md-offset-2

--- a/db/migrate/20170813141720_add_users_count_to_networks.rb
+++ b/db/migrate/20170813141720_add_users_count_to_networks.rb
@@ -1,0 +1,5 @@
+class AddUsersCountToNetworks < ActiveRecord::Migration[5.0]
+  def change
+    add_column :networks, :networks_users_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20170813144526_add_items_count_to_lists.rb
+++ b/db/migrate/20170813144526_add_items_count_to_lists.rb
@@ -1,0 +1,5 @@
+class AddItemsCountToLists < ActiveRecord::Migration[5.0]
+  def change
+    add_column :lists, :lists_items_count, :integer, default: 0
+  end
+end

--- a/db/migrate/20170813145314_add_lists_count_to_networks_and_resources.rb
+++ b/db/migrate/20170813145314_add_lists_count_to_networks_and_resources.rb
@@ -1,0 +1,6 @@
+class AddListsCountToNetworksAndResources < ActiveRecord::Migration[5.0]
+  def change
+    add_column :networks, :lists_items_count, :integer, default: 0
+    add_column :resources, :lists_items_count, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170813141720) do
+ActiveRecord::Schema.define(version: 20170813145314) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,15 +28,16 @@ ActiveRecord::Schema.define(version: 20170813141720) do
   end
 
   create_table "lists", force: :cascade do |t|
-    t.string   "name",                      null: false
+    t.string   "name",                           null: false
     t.string   "description"
-    t.string   "owner_type",                null: false
-    t.integer  "owner_id",                  null: false
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
-    t.text     "cached_tags",  default: [],              array: true
+    t.string   "owner_type",                     null: false
+    t.integer  "owner_id",                       null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.text     "cached_tags",       default: [],              array: true
     t.datetime "published_at"
-    t.integer  "privacy",      default: 1,  null: false
+    t.integer  "privacy",           default: 1,  null: false
+    t.integer  "lists_items_count", default: 0
     t.index ["owner_type", "owner_id"], name: "index_lists_on_owner_type_and_owner_id", using: :btree
   end
 
@@ -63,6 +64,7 @@ ActiveRecord::Schema.define(version: 20170813141720) do
     t.text     "cached_tags",          default: [],              array: true
     t.datetime "published_at"
     t.integer  "networks_users_count", default: 0
+    t.integer  "lists_items_count",    default: 0
   end
 
   create_table "networks_users", force: :cascade do |t|
@@ -76,18 +78,19 @@ ActiveRecord::Schema.define(version: 20170813141720) do
   end
 
   create_table "resources", force: :cascade do |t|
-    t.string   "title",                      null: false
-    t.integer  "resource_type", default: 0,  null: false
+    t.string   "title",                          null: false
+    t.integer  "resource_type",     default: 0,  null: false
     t.integer  "user_id"
-    t.datetime "created_at",                 null: false
-    t.datetime "updated_at",                 null: false
-    t.jsonb    "metadata",      default: {}, null: false
-    t.text     "cached_tags",   default: [],              array: true
-    t.integer  "privacy",       default: 0,  null: false
+    t.datetime "created_at",                     null: false
+    t.datetime "updated_at",                     null: false
+    t.jsonb    "metadata",          default: {}, null: false
+    t.text     "cached_tags",       default: [],              array: true
+    t.integer  "privacy",           default: 0,  null: false
     t.string   "url"
     t.datetime "published_at"
     t.text     "short_content"
     t.text     "long_content"
+    t.integer  "lists_items_count", default: 0
     t.index ["user_id"], name: "index_resources_on_user_id", using: :btree
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170615070755) do
+ActiveRecord::Schema.define(version: 20170813141720) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -54,14 +54,15 @@ ActiveRecord::Schema.define(version: 20170615070755) do
   end
 
   create_table "networks", force: :cascade do |t|
-    t.string   "name",                           null: false
+    t.string   "name",                              null: false
     t.string   "short_description"
     t.text     "long_description"
     t.json     "metadata"
-    t.datetime "created_at",                     null: false
-    t.datetime "updated_at",                     null: false
-    t.text     "cached_tags",       default: [],              array: true
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.text     "cached_tags",          default: [],              array: true
     t.datetime "published_at"
+    t.integer  "networks_users_count", default: 0
   end
 
   create_table "networks_users", force: :cascade do |t|

--- a/lib/tasks/counters.rake
+++ b/lib/tasks/counters.rake
@@ -1,7 +1,18 @@
 namespace :counters do
   desc 'Reset all networks counter caches'
   task reset_networks: :environment do
-    Network.find_each { |network| Network.reset_counters(network.id, :networks_users_count) }
-    Post.find_each { |post| Post.reset_counters(post.id, :comments) }
+    Network.find_each do |network|
+      Network.reset_counters(network.id, :networks_users_count, :lists_items_count)
+    end
+  end
+
+  desc 'Reset all resources counter caches'
+  task reset_resources: :environment do
+    Resource.find_each { |resource| Resource.reset_counters(resource.id, :lists_items_count) }
+  end
+
+  desc 'Reset all lists counter caches'
+  task reset_lists: :environment do
+    List.find_each { |list| List.reset_counters(list.id, :lists_items_count) }
   end
 end

--- a/lib/tasks/counters.rake
+++ b/lib/tasks/counters.rake
@@ -1,0 +1,7 @@
+namespace :counters do
+  desc 'Reset all networks counter caches'
+  task reset_networks: :environment do
+    Network.find_each { |network| Network.reset_counters(network.id, :networks_users_count) }
+    Post.find_each { |post| Post.reset_counters(post.id, :comments) }
+  end
+end


### PR DESCRIPTION
# Reason for change

Queries for the home and search pages are not currently optimized and using up too much memory on Heroku, causing errors.

# Changes

- Reduce the number of SQL queries made
- Add counter caches

# Note

This does not include view caching, which will be done in a future PR.