### PR TITLE
Fix alert position in form views

### DIFF
--- a/app/views/lists/_form.html.slim
+++ b/app/views/lists/_form.html.slim
@@ -1,11 +1,10 @@
 .row
   .col-xs-12.col-md-8.col-md-offset-2
     = form_for(list) do |f|
-      = render 'shared/alerts'
       - if list.errors.any?
         .page-details__row
           .alert.alert-warning role='alert'
-            p 
+            p
               = pluralize(list.errors.count, 'error')
               |  prohibited this list from being saved.
             ul
@@ -25,8 +24,8 @@
           = f.label :tag_list, 'Tags', class: 'control-label'
           .row
             .col-xs-12 data-gctagsinput='true'
-              = f.text_field :tag_list, value: @list.cached_tags.join(', '), 
-                                        class: 'form-control', 
+              = f.text_field :tag_list, value: @list.cached_tags.join(', '),
+                                        class: 'form-control',
                                         placeholder: 'Separate tags with commas...'
         .form-group
           .checkbox

--- a/app/views/lists/edit.html.slim
+++ b/app/views/lists/edit.html.slim
@@ -1,6 +1,9 @@
 .page-details--creme-bg
   .container
     .row
+      .col-xs-12
+        = render 'shared/alerts'
+    .row
       .col-xs-12.col-md-8.col-md-offset-2
         .form-box
           .form-box__title

--- a/app/views/lists/new.html.slim
+++ b/app/views/lists/new.html.slim
@@ -1,6 +1,9 @@
 .page-details--creme-bg
   .container
     .row
+      .col-xs-12
+        = render 'shared/alerts'
+    .row
       .col-xs-12.col-md-8.col-md-offset-2
         .form-box
           .form-box__title

--- a/app/views/networks/_form.html.slim
+++ b/app/views/networks/_form.html.slim
@@ -1,11 +1,10 @@
 .row
   .col-xs-12.col-md-8.col-md-offset-2
     = form_for(network) do |f|
-      = render 'shared/alerts'
       - if network.errors.any?
         .page-details__row
           .alert.alert-warning role='alert'
-            p 
+            p
               = pluralize(network.errors.count, 'error')
               |  prohibited this network from being saved.
             ul
@@ -25,8 +24,8 @@
           = f.label :tag_list, 'Tags', class: 'control-label'
           .row
             .col-xs-12 data-gctagsinput='true'
-              = f.text_field :tag_list, value: @network.cached_tags.join(', '), 
-                                        class: 'form-control', 
+              = f.text_field :tag_list, value: @network.cached_tags.join(', '),
+                                        class: 'form-control',
                                         placeholder: 'Separate tags with commas...'
         .form-group
           .pull-right

--- a/app/views/networks/edit.html.slim
+++ b/app/views/networks/edit.html.slim
@@ -1,6 +1,9 @@
 .page-details--creme-bg
   .container
     .row
+      .col-xs-12
+        = render 'shared/alerts'
+    .row
       .col-xs-12.col-md-8.col-md-offset-2
         .form-box
           .form-box__title

--- a/app/views/networks/new.html.slim
+++ b/app/views/networks/new.html.slim
@@ -1,6 +1,9 @@
 .page-details--creme-bg
   .container
     .row
+      .col-xs-12
+        = render 'shared/alerts'
+    .row
       .col-xs-12.col-md-8.col-md-offset-2
         .form-box
           .form-box__title

--- a/app/views/resources/_form.html.slim
+++ b/app/views/resources/_form.html.slim
@@ -1,11 +1,10 @@
 .row
   .col-xs-12.col-md-8.col-md-offset-2
     = form_for(resource) do |f|
-      = render 'shared/alerts'
       - if resource.errors.any?
         .page-details__row
           .alert.alert-warning role="alert"
-            p 
+            p
               = pluralize(resource.errors.count, "error")
               |  prohibited this resource from being saved.
             ul
@@ -17,7 +16,7 @@
           = f.text_field :title, class: "form-control", placeholder: "Resource title..."
         .form-group
           = f.label :url, "URL", class: "control-label"
-          = f.text_field :url, class: "form-control", placeholder: "Resource URL..."  
+          = f.text_field :url, class: "form-control", placeholder: "Resource URL..."
         .form-group
           .pull-right
             = f.submit submit_label, class: "form-control btn btn-gc"

--- a/app/views/resources/edit.html.slim
+++ b/app/views/resources/edit.html.slim
@@ -1,6 +1,9 @@
 .page-details--creme-bg
   .container
     .row
+      .col-xs-12
+        = render 'shared/alerts'
+    .row
       .col-xs-12.col-md-8.col-md-offset-2
         .form-box.form-box--middle
           .form-box__title

--- a/app/views/resources/new.html.slim
+++ b/app/views/resources/new.html.slim
@@ -1,6 +1,9 @@
 .page-details--creme-bg
   .container
     .row
+      .col-xs-12
+        = render 'shared/alerts'
+    .row
       .col-xs-12.col-md-8.col-md-offset-2
         .form-box.form-box--middle
           .form-box__title


### PR DESCRIPTION
# Reason for change

Currently, the notice/alert panel is shown inside the form box, but goes out of bounds.

# Changes

- Move the notice/alert outside of the form box, back at the top of the page like for the other pages.