### PR TITLE
Implement date filtering

### DIFF
--- a/app/assets/javascripts/filters.js
+++ b/app/assets/javascripts/filters.js
@@ -21,7 +21,7 @@ var initFilters = function() {
       end = moment.unix(daterange.data('end'));
     } else {
       start = moment().subtract(7, 'days');
-      end = moment()
+      end = moment();
     }
 
     daterange.daterangepicker({

--- a/app/assets/javascripts/filters.js
+++ b/app/assets/javascripts/filters.js
@@ -11,20 +11,49 @@ var initFilters = function() {
 
   $('input[name="daterange"]').each(function() {
     var daterange = $(this);
-    var start = daterange.data('start') ? moment.unix(daterange.data('start')) : moment().subtract(7, 'days');
-    var end = daterange.data('end') ? moment.unix(daterange.data('end')) : moment();
+    var filtering = false;
+    var start;
+    var end;
+
+    if (daterange.data('start') && daterange.data('end')) {
+      filtering = true;
+      start = moment.unix(daterange.data('start'));
+      end = moment.unix(daterange.data('end'));
+    } else {
+      start = moment().subtract(7, 'days');
+      end = moment()
+    }
 
     daterange.daterangepicker({
       "startDate": start,
       "endDate": end,
       "buttonClasses": "btn btn-sm btn-gc",
+      autoUpdateInput: false,
       locale: {
-        format: 'MM/DD/YYYY'
+        format: 'MM/DD/YYYY',
+        cancelLabel: 'Clear'
       }
-    }, function(start, end, label) {
+    });
+
+    if (filtering) {
+      $(this).val(start.format('MM/DD/YYYY') + ' - ' + end.format('MM/DD/YYYY'));
+    }
+
+    daterange.on('apply.daterangepicker', function(ev, picker) {
+      $(this).val(picker.startDate.format('MM/DD/YYYY') + ' - ' + picker.endDate.format('MM/DD/YYYY'));
+
       var url = new Uri(window.location.href);
-      url.replaceQueryParam('filters[start]', start.unix());
-      url.replaceQueryParam('filters[end]', end.unix());
+      url.replaceQueryParam('filters[start]', picker.startDate.unix());
+      url.replaceQueryParam('filters[end]', picker.endDate.unix());
+      reload(url);
+    });
+
+    daterange.on('cancel.daterangepicker', function(ev, picker) {
+      $(this).val('');
+
+      var url = new Uri(window.location.href);
+      url.deleteQueryParam('filters[start]');
+      url.deleteQueryParam('filters[end]');
       reload(url);
     });
   });
@@ -77,3 +106,4 @@ var initFilters = function() {
 $(document).on('ready turbolinks:load', function () {
   initFilters();
 });
+

--- a/app/assets/javascripts/filters.js
+++ b/app/assets/javascripts/filters.js
@@ -27,7 +27,7 @@ var initFilters = function() {
       url.replaceQueryParam('filters[end]', end.unix());
       reload(url);
     });
-  })
+  });
 
   $('[data-filter-select]').each(function() {
     var select = $(this);

--- a/app/assets/javascripts/filters.js
+++ b/app/assets/javascripts/filters.js
@@ -9,16 +9,25 @@ var initFilters = function() {
     });
   };
 
-  $('input[name="daterange"]').daterangepicker({
-    "startDate": moment().subtract(7, 'days'),
-    "endDate": moment(),
-    "buttonClasses": "btn btn-sm btn-gc",
-    locale: {
-      format: 'MM/DD/YYYY'
-    }
-  }, function(start, end, label) {
-    // Handle filtering
-  });
+  $('input[name="daterange"]').each(function() {
+    var daterange = $(this)
+    var start = daterange.data('start') ? moment.unix(daterange.data('start')) : moment().subtract(7, 'days')
+    var end = daterange.data('end') ? moment.unix(daterange.data('end')) : moment()
+
+    daterange.daterangepicker({
+      "startDate": start,
+      "endDate": end,
+      "buttonClasses": "btn btn-sm btn-gc",
+      locale: {
+        format: 'MM/DD/YYYY'
+      }
+    }, function(start, end, label) {
+      var url = new Uri(window.location.href);
+      url.replaceQueryParam('filters[start]', start.unix());
+      url.replaceQueryParam('filters[end]', end.unix());
+      reload(url);
+    });
+  })
 
   $('[data-filter-select]').each(function() {
     var select = $(this);

--- a/app/assets/javascripts/filters.js
+++ b/app/assets/javascripts/filters.js
@@ -10,9 +10,9 @@ var initFilters = function() {
   };
 
   $('input[name="daterange"]').each(function() {
-    var daterange = $(this)
-    var start = daterange.data('start') ? moment.unix(daterange.data('start')) : moment().subtract(7, 'days')
-    var end = daterange.data('end') ? moment.unix(daterange.data('end')) : moment()
+    var daterange = $(this);
+    var start = daterange.data('start') ? moment.unix(daterange.data('start')) : moment().subtract(7, 'days');
+    var end = daterange.data('end') ? moment.unix(daterange.data('end')) : moment();
 
     daterange.daterangepicker({
       "startDate": start,

--- a/app/services/search_builders/builder.rb
+++ b/app/services/search_builders/builder.rb
@@ -20,6 +20,11 @@ module SearchBuilders
       self
     end
 
+    def filter_by_date
+      @es_params = SearchBuilders::DateFilter.new(@filters, @es_params).build
+      self
+    end
+
     def sort
       @es_params = SearchBuilders::Sorter.new(@sort, @es_params).build
       self

--- a/app/services/search_builders/date_filter.rb
+++ b/app/services/search_builders/date_filter.rb
@@ -20,8 +20,8 @@ module SearchBuilders
       @es_params[:query][:bool][:filter][:bool][:should][:bool][:should] << {
         range: {
           published_at: {
-            lte: Time.at(@filters[:end].to_i).strftime('%Y-%m-%dT%H:%M:%SZ'),
-            gte: Time.at(@filters[:start].to_i).strftime('%Y-%m-%dT%H:%M:%SZ')
+            lte: Time.at(@filters[:end].to_i).strftime('%Y-%m-%dT23:59:59Z'),
+            gte: Time.at(@filters[:start].to_i).strftime('%Y-%m-%dT00:00:00Z')
           }
         }
       }

--- a/app/services/search_builders/date_filter.rb
+++ b/app/services/search_builders/date_filter.rb
@@ -6,7 +6,9 @@ module SearchBuilders
     end
 
     def build
-      return @es_params unless @filters[:start] && @filters[:end]
+      return @es_params unless @filters &&
+                               @filters[:start].present? &&
+                               @filters[:end].present?
 
       filter_by_date
       @es_params
@@ -23,7 +25,6 @@ module SearchBuilders
           }
         }
       }
-
     end
   end
 end

--- a/app/services/search_builders/date_filter.rb
+++ b/app/services/search_builders/date_filter.rb
@@ -1,0 +1,29 @@
+module SearchBuilders
+  class DateFilter
+    def initialize(filters, es_params)
+      @filters = filters || {}
+      @es_params = es_params
+    end
+
+    def build
+      return @es_params unless @filters[:start] && @filters[:end]
+
+      filter_by_date
+      @es_params
+    end
+
+    private
+
+    def filter_by_date
+      @es_params[:query][:bool][:filter][:bool][:should][:bool][:should] << {
+        range: {
+          published_at: {
+            lte: Time.at(@filters[:end].to_i).strftime('%Y-%m-%dT%H:%M:%SZ'),
+            gte: Time.at(@filters[:start].to_i).strftime('%Y-%m-%dT%H:%M:%SZ')
+          }
+        }
+      }
+
+    end
+  end
+end

--- a/app/services/search_builders/date_filter.rb
+++ b/app/services/search_builders/date_filter.rb
@@ -20,8 +20,8 @@ module SearchBuilders
       @es_params[:query][:bool][:filter][:bool][:should][:bool][:should] << {
         range: {
           published_at: {
-            lte: Time.at(@filters[:end].to_i).strftime('%Y-%m-%dT23:59:59Z'),
-            gte: Time.at(@filters[:start].to_i).strftime('%Y-%m-%dT00:00:00Z')
+            lte: Time.at(@filters[:end].to_i).strftime('%Y-%m-%dT%H:%M:%S'),
+            gte: Time.at(@filters[:start].to_i).strftime('%Y-%m-%dT%H:%M:%S')
           }
         }
       }

--- a/app/services/search_builders/date_filter.rb
+++ b/app/services/search_builders/date_filter.rb
@@ -20,8 +20,9 @@ module SearchBuilders
       @es_params[:query][:bool][:filter][:bool][:should][:bool][:should] << {
         range: {
           published_at: {
-            lte: Time.at(@filters[:end].to_i).strftime('%Y-%m-%dT%H:%M:%S'),
-            gte: Time.at(@filters[:start].to_i).strftime('%Y-%m-%dT%H:%M:%S')
+            lte: @filters[:end],
+            gte: @filters[:start],
+            format: 'epoch_second'
           }
         }
       }

--- a/app/services/search_builders/search.rb
+++ b/app/services/search_builders/search.rb
@@ -37,7 +37,7 @@ module SearchBuilders
         filters: @filters,
         sort: @sort,
         only_models: @models
-      ).search.filter_by_resource_type.sort
+      ).search.filter_by_date.filter_by_resource_type.sort
     end
   end
 end

--- a/app/views/search/_filters.html.slim
+++ b/app/views/search/_filters.html.slim
@@ -41,5 +41,5 @@
         span.filters__clear= link_to 'Clear', root_path, class: 'gray-light pull-right'
 
     .form-group.has-feedback
-      input name="daterange" type="text" class='form-control fw'
+      input name="daterange" data={ start: @filters[:start], end: @filters[:end] } type="text" class='form-control fw'
       i.glyphicon.glyphicon-calendar.form-control-feedback

--- a/app/views/search/_filters.html.slim
+++ b/app/views/search/_filters.html.slim
@@ -41,5 +41,5 @@
         span.filters__clear= link_to 'Clear', root_path, class: 'gray-light pull-right'
 
     .form-group.has-feedback
-      input name="daterange" data={ start: @filters.try(:start), end: @filters.try(:end) } type="text" class='form-control fw'
+      input name="daterange" data={ start: @filters ? @filters[:start] : '', end: @filters ? @filters[:end] : '' } type="text" class='form-control fw'
       i.glyphicon.glyphicon-calendar.form-control-feedback

--- a/app/views/search/_filters.html.slim
+++ b/app/views/search/_filters.html.slim
@@ -41,5 +41,5 @@
         span.filters__clear= link_to 'Clear', root_path, class: 'gray-light pull-right'
 
     .form-group.has-feedback
-      input name="daterange" data={ start: @filters[:start], end: @filters[:end] } type="text" class='form-control fw'
+      input name="daterange" data={ start: @filters.try(:start), end: @filters.try(:end) } type="text" class='form-control fw'
       i.glyphicon.glyphicon-calendar.form-control-feedback

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -165,6 +165,32 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
 
       expect(page).not_to have_text('My Resource')
     end
+
+    scenario 'users can filter by date' do
+      title = Faker::Hipster.sentence
+
+      create(:resource, title: "#{title} My Resource", resource_type: :article)
+
+      wait_for do
+        Elasticsearch::Model.search(title, [Resource]).results.total
+      end.to eq(1)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: title
+        find('.navbar__search-button').click
+      end
+
+      expect(page).to have_text('My Resource')
+
+      find('input[name=daterange]').click
+      all('.available')[3].click
+      all('.available')[6].click
+      find('.applyBtn').click
+      wait_for_ajax
+
+      expect(page).not_to have_text('My Resource')
+    end
   end
 
   context 'sorting' do

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -191,6 +191,25 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
 
       expect(page).not_to have_text('My Resource')
     end
+
+    scenario 'users can see filtered resources by date' do
+      title = Faker::Hipster.sentence
+
+      create(:resource, title: "#{title} My Resource", resource_type: :article,
+                        published_at: Time.parse('02-01-2017'))
+      create(:resource, title: "#{title} My Other Resource", resource_type: :article,
+                        published_at: Time.parse('09-01-2017'))
+
+      wait_for do
+        Elasticsearch::Model.search(title, [Resource]).results.total
+      end.to eq(2)
+
+      # Searching between 01/01/2017 and 07/01/2017
+      visit search_path(query: title, filters: { start: '1483225200', end: '1483829999' })
+
+      expect(page).to have_text('My Resource')
+      expect(page).not_to have_text('My Other Resource')
+    end
   end
 
   context 'sorting' do

--- a/spec/services/search_builders/date_filter_spec.rb
+++ b/spec/services/search_builders/date_filter_spec.rb
@@ -1,0 +1,66 @@
+require 'rails_helper'
+
+RSpec.describe SearchBuilders::DateFilter do
+  describe '#build' do
+    context 'with filters = nil' do
+      it 'returns the given es params' do
+        filter = SearchBuilders::DateFilter.new(nil, something: 'else')
+        expect(filter.build).to eq(something: 'else')
+      end
+    end
+
+    context 'with filters = {}' do
+      it 'returns the given es params' do
+        filter = SearchBuilders::DateFilter.new({}, something: 'else')
+        expect(filter.build).to eq(something: 'else')
+      end
+    end
+
+    context 'with filters = { start: nil, end: nil }' do
+      it 'returns the given es params' do
+        filter = SearchBuilders::DateFilter.new({ start: nil, end: nil },
+                                                something: 'else')
+        expect(filter.build).to eq(something: 'else')
+      end
+    end
+
+    context 'with filters = { start: "", end: "" }' do
+      it 'returns the given es params' do
+        filter = SearchBuilders::DateFilter.new({ start: '', end: '' },
+                                                something: 'else')
+        expect(filter.build).to eq(something: 'else')
+      end
+    end
+
+    context 'with filters = { start: "1483657200", end: "1483829999" }' do
+      it 'builds the es params with the right conditions' do
+        es_params = SearchBuilders::Builder.new.es_params
+
+        filter = SearchBuilders::DateFilter.new(
+          {
+            start: '1483657200', end: '1483829999'
+          },
+          es_params
+        )
+
+        expect(filter.build[:query][:bool][:filter][:bool]).to eq(
+          should: {
+            bool: {
+              minimum_should_match: 1,
+              should: [
+                {
+                  range: {
+                    published_at: {
+                      lte: '2017-01-07T23:59:59Z',
+                      gte: '2017-01-06T00:00:00Z'
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        )
+      end
+    end
+  end
+end

--- a/spec/services/search_builders/date_filter_spec.rb
+++ b/spec/services/search_builders/date_filter_spec.rb
@@ -51,8 +51,8 @@ RSpec.describe SearchBuilders::DateFilter do
                 {
                   range: {
                     published_at: {
-                      lte: '2017-01-07T23:59:59Z',
-                      gte: '2017-01-06T00:00:00Z'
+                      lte: '2017-01-07T23:59:59',
+                      gte: '2017-01-06T00:00:00'
                     }
                   }
                 }

--- a/spec/services/search_builders/date_filter_spec.rb
+++ b/spec/services/search_builders/date_filter_spec.rb
@@ -51,8 +51,9 @@ RSpec.describe SearchBuilders::DateFilter do
                 {
                   range: {
                     published_at: {
-                      lte: '2017-01-07T23:59:59',
-                      gte: '2017-01-06T00:00:00'
+                      lte: '1483829999',
+                      gte: '1483657200',
+                      format: 'epoch_second'
                     }
                   }
                 }


### PR DESCRIPTION
# Reason for change

Date filtering is currently not implemented, this PR adds it.

# Changes

- Add date filtering
- Add tests to ensure dates can be selected and URLs containing the filters are correctly interpreted by the calendar