### PR TITLE
Search by tags

### DIFF
--- a/app/services/search_builders/builder.rb
+++ b/app/services/search_builders/builder.rb
@@ -52,6 +52,7 @@ module SearchBuilders
             },
             filter: {
               bool: {
+                must: [],
                 should: {
                   bool: {
                     minimum_should_match: 1,

--- a/app/services/search_builders/query.rb
+++ b/app/services/search_builders/query.rb
@@ -10,7 +10,7 @@ module SearchBuilders
       'metadata.publisher': 1,
       'metadata.creators': 1,
       'metadata.isbn': 1,
-      tags: 10
+      tags: 1
     }.freeze
 
     def initialize(query, es_params)
@@ -21,10 +21,18 @@ module SearchBuilders
     def build
       return @es_params if @query.blank?
 
-      QUERY_KEYS.each do |key, value|
-        @es_params[:query][:bool][:must][:bool][:should] << {
-          match: { key => { query: @query, boost: value } }
+      if @query[0] == '#'
+        @es_params[:query][:bool][:filter][:bool][:must] << {
+          terms: {
+            tags: @query[1..-1].split(' ')
+          }
         }
+      else
+        QUERY_KEYS.each do |key, value|
+          @es_params[:query][:bool][:must][:bool][:should] << {
+            match: { key => { query: @query, boost: value } }
+          }
+        end
       end
 
       @es_params

--- a/app/services/search_builders/query.rb
+++ b/app/services/search_builders/query.rb
@@ -1,15 +1,16 @@
 module SearchBuilders
   class Query
-    QUERY_KEYS = %i{
-      title
-      name
-      short_content
-      long_content
-      short_description
-      long_description
-      metadata.publisher
-      metadata.creators
-      metadata.isbn
+    QUERY_KEYS = {
+      title: 1,
+      name: 1,
+      short_content: 1,
+      long_content: 1,
+      short_description: 1,
+      long_description: 1,
+      'metadata.publisher': 1,
+      'metadata.creators': 1,
+      'metadata.isbn': 1,
+      tags: 10
     }.freeze
 
     def initialize(query, es_params)
@@ -20,8 +21,10 @@ module SearchBuilders
     def build
       return @es_params if @query.blank?
 
-      QUERY_KEYS.each do |key|
-        @es_params[:query][:bool][:must][:bool][:should] << { match: { key => @query } }
+      QUERY_KEYS.each do |key, value|
+        @es_params[:query][:bool][:must][:bool][:should] << {
+          match: { key => { query: @query, boost: value } }
+        }
       end
 
       @es_params

--- a/app/views/search/_filters.html.slim
+++ b/app/views/search/_filters.html.slim
@@ -25,13 +25,9 @@
         | Tags
         span.filters__clear= link_to 'Clear', root_path, class: 'gray-light pull-right'
     .tags-list
-      = link_to '#urban sustainability (245)', root_path, class: 'tags-list__tag'
-      = link_to '#solar energy (148)', root_path, class: 'tags-list__tag'
-      = link_to '#wind (136)', root_path, class: 'tags-list__tag tags-list__tag--selected'
-      = link_to '#ocean (136)', root_path, class: 'tags-list__tag tags-list__tag--selected'
-      = link_to '#solar energy (148)', root_path, class: 'tags-list__tag'
-      = link_to '#solar (148)', root_path, class: 'tags-list__tag'
-      .clearfix
+      - ActsAsTaggableOn::Tag.most_used(10).each do |tag|
+        = link_to "##{tag.name} (#{tag.taggings_count})", search_path(query: tag.name), class: 'tags-list__tag'
+        .clearfix
     .filters__tags-show-more
       = link_to 'Show more', root_path
   .filters
@@ -43,3 +39,4 @@
     .form-group.has-feedback
       input name="daterange" data={ start: @filters ? @filters[:start] : '', end: @filters ? @filters[:end] : '' } type="text" class='form-control fw'
       i.glyphicon.glyphicon-calendar.form-control-feedback
+

--- a/app/views/search/_filters.html.slim
+++ b/app/views/search/_filters.html.slim
@@ -26,7 +26,7 @@
         span.filters__clear= link_to 'Clear', root_path, class: 'gray-light pull-right'
     .tags-list
       - ActsAsTaggableOn::Tag.most_used(10).each do |tag|
-        = link_to "##{tag.name} (#{tag.taggings_count})", search_path(query: tag.name), class: 'tags-list__tag'
+        = link_to "##{tag.name} (#{tag.taggings_count})", search_path(query: "##{tag.name}"), class: 'tags-list__tag'
         .clearfix
     .filters__tags-show-more
       = link_to 'Show more', root_path

--- a/app/views/shared/components/_tags_list.html.slim
+++ b/app/views/shared/components/_tags_list.html.slim
@@ -2,5 +2,6 @@
   .summary-card__row
     .tags-list
       - tags.each_with_index do |tag, i|
-          = link_to "##{tag}", search_path(query: tag), class: 'tags-list__tag'
+          = link_to "##{tag}", search_path(query: "##{tag}"), class: 'tags-list__tag'
       .clearfix
+

--- a/app/views/static_pages/_hero.html.slim
+++ b/app/views/static_pages/_hero.html.slim
@@ -16,19 +16,19 @@
           .fa.fa-info-circle.home-header__info-icon
           = ' Not sure where to start?'
           = ' Try searching for '
-          = link_to 'solar panels', search_path(query: 'solar panels'), class: 'home-header__hero-link'
+          = link_to 'solar panels', search_path(query: '#solar panels'), class: 'home-header__hero-link'
           = ', '
-          = link_to 'greenhouse', search_path(query: 'greenhouse'), class: 'home-header__hero-link'
+          = link_to 'greenhouse', search_path(query: '#greenhouse'), class: 'home-header__hero-link'
           = ', '
-          = link_to 'gas emissions', search_path(query: 'gas emissions'), class: 'home-header__hero-link'
+          = link_to 'gas emissions', search_path(query: '#gas emissions'), class: 'home-header__hero-link'
           = ' or '
-          = link_to 'municipal data sets', search_path(query: 'municipal data sets'), class: 'home-header__hero-link'
+          = link_to 'municipal data sets', search_path(query: '#municipal data sets'), class: 'home-header__hero-link'
     .row
       .col-xs-12.col-sm-8.col-sm-offset-2
         .home-header__hero-tags
           .tags-list
             - ActsAsTaggableOn::Tag.most_used.limit(6).each_with_index do |tag, i|
-                = link_to "##{tag}", search_path(query: tag.name), class: 'tags-list__tag tags-list__tag--white'
+                = link_to "##{tag}", search_path(query: "##{tag.name}"), class: 'tags-list__tag tags-list__tag--white'
             .clearfix
     .row
       .col-xs-12.col-sm-8.col-sm-offset-2.col-md-10.col-md-offset-1.col-lg-8.col-lg-offset-2
@@ -45,3 +45,4 @@
             .col-xs-12.col-md-4
               = render 'shared/components/box', svg: 'running', title: 'ACT', color: 'orange',
                 content: 'Join a network or start your own. Analyze data. Connect ideas to ideas, people to ideas, and people to people. Organize a project. Have an impact.'
+

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -332,4 +332,3 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
     end
   end
 end
-

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -112,6 +112,34 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
     end
   end
 
+  context 'tags' do
+    scenario 'users can search for resources, networks and lists' do
+      resource = create(:resource, title: 'Super Resource')
+      network = create(:network, name: 'Super Network')
+
+      resource.tag_list.add('ocean')
+      resource.tag_list.add('sky')
+      resource.save!
+
+      network.tag_list.add('earth')
+      network.tag_list.add('cloud')
+      network.save!
+
+      wait_for do
+        Elasticsearch::Model.search('super', [Resource, Network, List]).results.total
+      end.to eq(2)
+
+      visit new_search_path
+      within('.customer-search-form') do
+        fill_in 'query', with: 'sky'
+        find('.navbar__search-button').click
+      end
+
+      expect(page).to have_text('Super Resource')
+      expect(page).not_to have_text('Super Network')
+    end
+  end
+
   context 'filtering' do
     scenario 'users can filter by model', js: true do
       title = Faker::Hipster.sentence

--- a/spec/feature/user_searches_resources_spec.rb
+++ b/spec/feature/user_searches_resources_spec.rb
@@ -114,8 +114,10 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
 
   context 'tags' do
     scenario 'users can search for resources, networks and lists' do
-      resource = create(:resource, title: 'Super Resource')
-      network = create(:network, name: 'Super Network')
+      title = Faker::Hipster.sentence
+
+      resource = create(:resource, title: "Resource #{title}")
+      network = create(:network, name: "Network #{title}")
 
       resource.tag_list.add('ocean')
       resource.tag_list.add('sky')
@@ -126,17 +128,21 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
       network.save!
 
       wait_for do
-        Elasticsearch::Model.search('super', [Resource, Network, List]).results.total
-      end.to eq(2)
+        Elasticsearch::Model.search('ocean', [Resource]).results.total
+      end.to eq(1)
+
+      wait_for do
+        Elasticsearch::Model.search('earth', [Network]).results.total
+      end.to eq(1)
 
       visit new_search_path
       within('.customer-search-form') do
-        fill_in 'query', with: 'sky'
+        fill_in 'query', with: 'ocean'
         find('.navbar__search-button').click
       end
 
-      expect(page).to have_text('Super Resource')
-      expect(page).not_to have_text('Super Network')
+      expect(page).to have_text("Resource #{title}")
+      expect(page).not_to have_text("Network #{title}")
     end
   end
 
@@ -326,3 +332,4 @@ RSpec.feature 'Searching for resources', :worker, :elasticsearch do
     end
   end
 end
+

--- a/spec/services/search_builders/date_filter_spec.rb
+++ b/spec/services/search_builders/date_filter_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe SearchBuilders::DateFilter do
         )
 
         expect(filter.build[:query][:bool][:filter][:bool]).to eq(
+          must: [],
           should: {
             bool: {
               minimum_should_match: 1,

--- a/spec/services/search_builders/query_spec.rb
+++ b/spec/services/search_builders/query_spec.rb
@@ -22,9 +22,10 @@ RSpec.describe SearchBuilders::Query do
         query = SearchBuilders::Query.new('test', es_params)
 
         expect(query.build[:query][:bool][:filter]).to eq(
-          bool: { should: { bool: { minimum_should_match: 1, should: [] } } }
+          bool: { must: [], should: { bool: { minimum_should_match: 1, should: [] } } }
         )
       end
     end
   end
 end
+

--- a/spec/services/search_builders/query_spec.rb
+++ b/spec/services/search_builders/query_spec.rb
@@ -28,4 +28,3 @@ RSpec.describe SearchBuilders::Query do
     end
   end
 end
-

--- a/spec/services/search_builders/resource_type_filter_spec.rb
+++ b/spec/services/search_builders/resource_type_filter_spec.rb
@@ -44,6 +44,7 @@ RSpec.describe SearchBuilders::ResourceTypeFilter do
         )
 
         expect(filter.build[:query][:bool][:filter][:bool]).to eq(
+          must: [],
           should: {
             bool: {
               minimum_should_match: 1,
@@ -69,6 +70,7 @@ RSpec.describe SearchBuilders::ResourceTypeFilter do
         )
 
         expect(filter.build[:query][:bool][:filter][:bool]).to eq(
+          must: [],
           should: {
             bool: {
               minimum_should_match: 1,
@@ -83,3 +85,4 @@ RSpec.describe SearchBuilders::ResourceTypeFilter do
     end
   end
 end
+

--- a/spec/services/search_builders/resource_type_filter_spec.rb
+++ b/spec/services/search_builders/resource_type_filter_spec.rb
@@ -85,4 +85,3 @@ RSpec.describe SearchBuilders::ResourceTypeFilter do
     end
   end
 end
-


### PR DESCRIPTION
[Trello Task](https://trello.com/c/tOUulYpo/114-green-commons-enable-searching-by-tag-only)

# Reason for change

Currently, tags are not used in the search process. This needs to be altered in order to have tags as primary matchers.

# Changes

- Include tags in the search process
- Update the list of tags in the search filters sidebar
