### PR TITLE
Fix resource page

### DIFF
--- a/app/helpers/icon_helper.rb
+++ b/app/helpers/icon_helper.rb
@@ -1,6 +1,6 @@
 module IconHelper
   def resource_icon(resource)
-    if resource.resource_type.in?(%w(article book report))
+    if resource.resource_type.to_sym.in?(Resource::RESOURCE_TYPES.keys)
       render "shared/icons/#{resource.resource_type}"
     else
       render 'shared/icons/unknown'

--- a/app/views/lists/show.html.slim
+++ b/app/views/lists/show.html.slim
@@ -42,7 +42,7 @@
                       = "Published Date: #{humanize_date(@list.published_at)}"
                     .page-details__metadata 
                       i.fa.fa-lock.glyphicon--right
-                      = "Privacy: #{@list.priv? ? 'Private' : 'Public'}"
+                      = "License: #{@list.priv? ? 'Private' : 'Public'}"
                   .clearfix
               .row
                 .page-details__row

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -29,7 +29,7 @@
                                              data: { confirm: 'Are you sure?' } do
                           | Delete
                           i.fa.fa-times.glyphicon--left
-                      - if @resource.url
+                      - unless @resource.url.blank?
                         = link_to via_hypothesis(@resource.url), target: '_blank', class: 'resource-actions__button btn btn-dark-blue'
                           | View Original
                           i.fa.fa-link.glyphicon--left

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -58,7 +58,7 @@
                       = "Publisher: #{@resource.publisher}"
                     .page-details__metadata
                       i.fa.fa-lock.glyphicon--right
-                      = "Privacy: #{@resource.priv? ? 'Private' : 'Public'}"
+                      = "License: #{@resource.priv? ? 'Private' : 'Public'}"
                   .clearfix
               .row
                 .page-details__row

--- a/app/views/resources/show.html.slim
+++ b/app/views/resources/show.html.slim
@@ -96,18 +96,6 @@
                 .col-xs-12.col-md-9
                   .row
                     .col-xs-12
-                      .page-details__section-title.page-details__section-title--underline
-                        h6
-                          | Content viewer
-                      .resource-page__empty-content-viewer
-                        .row
-                          .col-xs-12
-                            i.fa.fa-frown-o
-                        .row
-                          .col-xs-12
-                            p Oops... Nothing Available
-                  .row
-                    .col-xs-12
                       .page-details__row--double
                         = render 'shared/integrations/disqus/comments', entity: @resource
 
@@ -119,3 +107,4 @@
                     ul.sidelist
                       - @suggestions.each do |suggestion|
                         li= link_to suggestion.name, resource_type_path(suggestion)
+

--- a/app/views/shared/components/_content_viewer.html.slim
+++ b/app/views/shared/components/_content_viewer.html.slim
@@ -1,0 +1,13 @@
+.row
+  .col-xs-12
+    .page-details__section-title.page-details__section-title--underline
+      h6
+        | Content viewer
+    .resource-page__empty-content-viewer
+      .row
+        .col-xs-12
+          i.fa.fa-frown-o
+      .row
+        .col-xs-12
+          p Oops... Nothing Available
+

--- a/app/views/shared/icons/_audio.html.slim
+++ b/app/views/shared/icons/_audio.html.slim
@@ -1,0 +1,2 @@
+i.fa.fa-volume-up
+

--- a/app/views/shared/icons/_course.html.slim
+++ b/app/views/shared/icons/_course.html.slim
@@ -1,0 +1,2 @@
+i.fa.fa-graduation-cap
+

--- a/app/views/shared/icons/_dataset.html.slim
+++ b/app/views/shared/icons/_dataset.html.slim
@@ -1,0 +1,2 @@
+i.fa.fa-database
+

--- a/app/views/shared/icons/_image.html.slim
+++ b/app/views/shared/icons/_image.html.slim
@@ -1,0 +1,2 @@
+i.fa.fa-image
+

--- a/app/views/shared/icons/_profile.html.slim
+++ b/app/views/shared/icons/_profile.html.slim
@@ -1,0 +1,2 @@
+i.fa.fa-user
+

--- a/app/views/shared/icons/_syllabus.html.slim
+++ b/app/views/shared/icons/_syllabus.html.slim
@@ -1,0 +1,2 @@
+i.fa.fa-university
+

--- a/app/views/shared/icons/_url.html.slim
+++ b/app/views/shared/icons/_url.html.slim
@@ -1,0 +1,2 @@
+i.fa.fa-link
+

--- a/app/views/shared/icons/_video.html.slim
+++ b/app/views/shared/icons/_video.html.slim
@@ -1,0 +1,2 @@
+i.fa.fa-video-camera
+


### PR DESCRIPTION
This pull request contains a few minor changes to the resource page.

# Trello tasks

- [Remove the content viewer section](https://trello.com/c/c6alismC/112-green-commons-remove-the-content-viewer-section-from-resource-pages)
- [Hide View Original](https://trello.com/c/exvRQcUu/103-green-commons-hide-view-original-when-there-is-no-link)
- [Add icons for all resource types](https://trello.com/c/V0F6X5lk/104-green-commons-profile-icon-is-missing)
- [Change Privacy to License](https://trello.com/c/DxNPaGRq/113-green-commons-resource-page-change-privacy-to-license)