### PR TITLE
Issue #255 - Create rake task for create indices in ElasticSearch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ To start the app locally run the command (make sure postgres is running):
 
 You should be able to visit http://localhost:3000/ within your browser and see the Green Commons homepage.
 
+If you get errors from ElasticSearch on startup, try running the following command in the Console:
+
+    rake elasticsearch:create:all_indices
+
 Developing
 ----------
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ To start the app locally run the command (make sure postgres is running):
 
 You should be able to visit http://localhost:3000/ within your browser and see the Green Commons homepage.
 
-If you get errors from ElasticSearch on startup, try running the following command in the Console:
+You will need to run the following while you have foreman running in another terminal window, otherwise you will get ElasticSearch errors:
 
     rake elasticsearch:create:all_indices
 

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,46 +1,83 @@
 namespace :elasticsearch do
-  def reset_index(klass)
-    client = Elasticsearch::Client.new(
+  namespace :reset do
+
+    def reset_index(klass)
+      client = Elasticsearch::Client.new(
       url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log: true
-    )
+      )
 
-    if client.indices.exists? index: klass.index_name
-      client.indices.delete index: klass.index_name
+      if client.indices.exists? index: klass.index_name
+        client.indices.delete index: klass.index_name
+      end
+
+      klass.__elasticsearch__.create_index! force: true
+
+      begin
+        klass.import
+      rescue Faraday::ConnectionFailed => e
+        ap e
+        ap 'Indexing records one at a time...'
+        klass.all.each { |r| r.__elasticsearch__.index_document }
+      end
     end
 
-    klass.__elasticsearch__.create_index! force: true
+    desc 'Deletes the "resource", "network" and "list" indices and regenerates it with all records'
+    task all_indices: :environment do
+      [Resource, Network, List, User].each { |klass| reset_index(klass) }
+    end
 
-    begin
+    desc 'Deletes the "resource" index and regenerates it with all records currently in Resource'
+    task resource_index: :environment do
+      reset_index(Resource)
+    end
+
+    desc 'Deletes the "network" index and regenerates it with all records currently in Network'
+    task network_index: :environment do
+      reset_index(Network)
+    end
+
+    desc 'Deletes the "list" index and regenerates it with all records currently in List'
+    task list_index: :environment do
+      reset_index(List)
+    end
+
+    desc 'Deletes the "user" index and regenerates it with all records currently in List'
+    task list_index: :environment do
+      reset_index(User)
+    end
+  end
+
+  namespace :create do
+    def create_index(klass)
+      ap "Creating #{klass.name} index"
+      klass.__elasticsearch__.create_index!
+      ap "Indexing #{klass.name} records"
       klass.import
-    rescue Faraday::ConnectionFailed => e
-      ap e
-      ap 'Indexing records one at a time...'
-      klass.all.each { |r| r.__elasticsearch__.index_document }
     end
-  end
 
-  desc 'Deletes the "resource", "network" and "list" indices and regenerates it with all records'
-  task reset_all_indices: :environment do
-    [Resource, Network, List, User].each { |klass| reset_index(klass) }
-  end
+    desc 'Creates the "resource", "network" and "list" indices and regenerates it with all records'
+    task all_indices: :environment do
+      [Resource, Network, List, User].each { |klass| create_index(klass) }
+    end
 
-  desc 'Deletes the "resource" index and regenerates it with all records currently in Resource'
-  task reset_resource_index: :environment do
-    reset_index(Resource)
-  end
+    desc 'Creates the "resource" index and regenerates it with all records currently in Resource'
+    task resource_index: :environment do
+      create_index(Resource)
+    end
 
-  desc 'Deletes the "network" index and regenerates it with all records currently in Network'
-  task reset_network_index: :environment do
-    reset_index(Network)
-  end
+    desc 'Creates the "network" index and regenerates it with all records currently in Network'
+    task network_index: :environment do
+      create_index(Network)
+    end
 
-  desc 'Deletes the "list" index and regenerates it with all records currently in List'
-  task reset_list_index: :environment do
-    reset_index(List)
-  end
+    desc 'Creates the "list" index and regenerates it with all records currently in List'
+    task list_index: :environment do
+      create_index(List)
+    end
 
-  desc 'Deletes the "user" index and regenerates it with all records currently in List'
-  task reset_list_index: :environment do
-    reset_index(User)
+    desc 'Creates the "user" index and regenerates it with all records currently in List'
+    task list_index: :environment do
+      create_index(User)
+    end
   end
 end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -20,7 +20,7 @@ namespace :elasticsearch do
       end
     end
 
-    desc 'Deletes the "resource", "network" and "list" indices and regenerates it with all records'
+    desc 'Deletes the "resource", "network", "user" and "list" indices and regenerates it with all records'
     task all_indices: :environment do
       [Resource, Network, List, User].each { |klass| reset_index(klass) }
     end
@@ -41,7 +41,7 @@ namespace :elasticsearch do
     end
 
     desc 'Deletes the "user" index and regenerates it with all records currently in List'
-    task list_index: :environment do
+    task user_index: :environment do
       reset_index(User)
     end
   end
@@ -54,7 +54,7 @@ namespace :elasticsearch do
       klass.import
     end
 
-    desc 'Creates the "resource", "network" and "list" indices and regenerates it with all records'
+    desc 'Creates the "resource", "network", "user" and "list" indices and regenerates it with all records'
     task all_indices: :environment do
       [Resource, Network, List, User].each { |klass| create_index(klass) }
     end
@@ -75,7 +75,7 @@ namespace :elasticsearch do
     end
 
     desc 'Creates the "user" index and regenerates it with all records currently in List'
-    task list_index: :environment do
+    task user_index: :environment do
       create_index(User)
     end
   end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -20,7 +20,10 @@ namespace :elasticsearch do
       end
     end
 
-    desc 'Deletes the "resource", "network", "user" and "list" indices and regenerates it with all records'
+    desc([
+      'Deletes the "resource", "network", "user"',
+      ' and "list" indices and regenerates it with all records'
+    ].join)
     task all_indices: :environment do
       [Resource, Network, List, User].each { |klass| reset_index(klass) }
     end
@@ -54,7 +57,10 @@ namespace :elasticsearch do
       klass.import
     end
 
-    desc 'Creates the "resource", "network", "user" and "list" indices and regenerates it with all records'
+    desc([
+      'Creates the "resource", "network", "user"',
+      ' and "list" indices and regenerates it with all records'
+    ].join)
     task all_indices: :environment do
       [Resource, Network, List, User].each { |klass| create_index(klass) }
     end

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -1,9 +1,8 @@
 namespace :elasticsearch do
   namespace :reset do
-
     def reset_index(klass)
       client = Elasticsearch::Client.new(
-      url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log: true
+        url: ENV.fetch('BONSAI_URL', 'http://localhost:9200'), log: true
       )
 
       if client.indices.exists? index: klass.index_name


### PR DESCRIPTION
Related to issue #255 

- Added rake task for create indices on ElasticSearch for Resource, Network, List and User records. 
- Readme.md Updated.

Also I added the proper namespace to the elastic_search reset tasks.