### PR TITLE
Fixed Connect carousel last indicator and network display items changed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -65,4 +65,5 @@ group :test do
   gem 'capybara-webkit'
   gem 'capybara-screenshot'
   gem 'json_matchers'
+  gem 'rails-controller-testing'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -281,6 +281,10 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0.1)
       sprockets-rails (>= 2.0.0)
+    rails-controller-testing (1.0.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
@@ -444,6 +448,7 @@ DEPENDENCIES
   pundit
   pundit-matchers (~> 1.1.0)
   rails (~> 5.0.0, >= 5.0.0.1)
+  rails-controller-testing
   react-rails (~> 1.10)
   rspec-rails (~> 3.5)
   rspec-wait
@@ -464,4 +469,4 @@ RUBY VERSION
    ruby 2.3.2p217
 
 BUNDLED WITH
-   1.13.6
+   1.15.4

--- a/app/assets/stylesheets/components/_carousel-indicators.scss
+++ b/app/assets/stylesheets/components/_carousel-indicators.scss
@@ -1,5 +1,4 @@
 .gc-carousel-indicators {
-  position: relative;
   bottom: 0;
   top: 53px;
 

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -3,6 +3,7 @@ class StaticPagesController < ApplicationController
 
   def home
     @counts = Resource.group(:resource_type).count
+    @networks = Network.includes(:users).sample(10)
   end
 
   def policy; end

--- a/app/views/static_pages/_connect.html.slim
+++ b/app/views/static_pages/_connect.html.slim
@@ -26,7 +26,7 @@
               #carousel-connect.carousel.slide data-ride="carousel"
                 .row
                   .carousel-inner.home-connect__feature-carousel role="listbox"
-                    - Network.includes(:users).limit(9).each_with_index do |network, index|
+                    - networks.each_with_index do |network, index|
                       div class="#{index == 0 ? 'item active' : 'item'}"
                         .col-xs-12
                           = render 'shared/summary_cards/mini/network', network: network
@@ -119,4 +119,3 @@
                             g#3 transform="translate(824.000000, 0.000000)"
                               g#Path-14
                                 path#Shape d="M60.5454545,496 C64.2622727,496 67.2727273,493.09125 67.2727273,489.5 C67.2727273,485.90875 64.2622727,483 60.5454545,483 C56.8286364,483 53.8181818,485.90875 53.8181818,489.5 C53.8181818,493.09125 56.8286364,496 60.5454545,496 Z M45.4090909,492.75 L45.4090909,487.875 L42.0454545,487.875 L42.0454545,492.75 L37,492.75 L37,496 L42.0454545,496 L42.0454545,500.875 L45.4090909,500.875 L45.4090909,496 L50.4545455,496 L50.4545455,492.75 L45.4090909,492.75 Z M60.5454545,499.25 C56.055,499.25 47.0909091,501.4275 47.0909091,505.75 L47.0909091,509 L74,509 L74,505.75 C74,501.4275 65.0359091,499.25 60.5454545,499.25 Z"
-

--- a/app/views/static_pages/home.html.slim
+++ b/app/views/static_pages/home.html.slim
@@ -12,7 +12,7 @@ html
       = render 'shared/home_nav'
       = render 'static_pages/hero'
     = render 'static_pages/content'
-    = render 'static_pages/connect'
+    = render 'static_pages/connect', networks: @networks
 
 
     = render 'shared/home_footer'

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -1,0 +1,36 @@
+require 'rails_helper'
+
+RSpec.describe StaticPagesController, type: :controller do
+  describe 'GET #home' do
+    def perform_request
+      get :home
+    end
+
+    let(:counts) do
+      { 0 => 20, 1 => 20, 3 => 20, 4 => 20 }
+    end
+
+    before do
+      20.times do
+        create(:network)
+        create(:book)
+        create(:article)
+        create(:url)
+        create(:audio)
+      end
+      perform_request
+    end
+
+    it 'responds with success' do
+      expect(response).to be_success
+    end
+
+    it 'assigns 10 random networks' do
+      expect(assigns(:networks).count).to eq(10)
+    end
+
+    it 'assigns resource count by resource type' do
+      expect(assigns(:counts)).to eq(counts)
+    end
+  end
+end

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -5,4 +5,22 @@ FactoryGirl.define do
     short_content { Faker::Hipster.paragraph }
     privacy 'publ'
   end
+
+  factory :book, parent: :resource
+
+  factory :article, parent: :resource do
+    resource_type { :article }
+  end
+
+  factory :report, parent: :resource do
+    resource_type { :report }
+  end
+
+  factory :url, parent: :resource do
+    resource_type { :url }
+  end
+
+  factory :audio, parent: :resource do
+    resource_type { :audio }
+  end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,7 @@ end
 RSpec.configure do |config|
   config.include ActiveSupport::Testing::TimeHelpers
   config.include Devise::Test::IntegrationHelpers, type: :request
+  config.include Devise::Test::ControllerHelpers, type: :controller
   config.filter_rails_from_backtrace!
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.infer_spec_type_from_file_location!


### PR DESCRIPTION
Changes: 

  * Last carousel indicator shows the network last card
  * The Network displayed now are 10 and are random
  * Fixed the display position of the last indicator for small desktop screens.
  * Also added a new dependency on testing env: `rails-controller-testing`. It provides the `assigns` helper method.

Notes:
  * I moved the Network DB query outside of the view. Reason: Anti pattern.

#189 