### PR TITLE
Issue  #199 - Replace links of resources. Goes to the search page

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -4,6 +4,14 @@ class StaticPagesController < ApplicationController
   def home
     @counts = Resource.group(:resource_type).count
     @networks = Network.includes(:users).sample(10)
+    @books = Resource.books.sample(6)
+    @articles = Resource.articles.sample(6)
+    @reports = Resource.reports.sample(6)
+    @audios = Resource.audios.sample(6)
+    @courses = Resource.courses.sample(6)
+    @datasets = Resource.datasets.sample(6)
+    @syllabuses = Resource.syllabuses.sample(6)
+    @videos = Resource.videos.sample(6)
   end
 
   def policy; end

--- a/app/views/shared/components/_resource_details.html.slim
+++ b/app/views/shared/components/_resource_details.html.slim
@@ -13,6 +13,5 @@
 
   .row
     .col-xs-12
-      = link_to root_path, class: 'resource-details__see-more' do
-        | See more
-        .fa.fa-arrow-right.glyphicon--left
+      = link_to search_path(query: '', filters: { model_types: {resources: 'on'}, resource_types: { resource_type.to_s.pluralize => 'on'}, sort: 'score' }), class: 'resource-details__see-more' do
+        | View All

--- a/app/views/static_pages/_content.html.slim
+++ b/app/views/static_pages/_content.html.slim
@@ -15,43 +15,50 @@
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Books',
                                                                      count: @counts[Resource::RESOURCE_TYPES[:book]],
-                                                                     list: Resource.books.order("RANDOM()").limit(6)
+                                                                     list: @books,
+                                                                     resource_type: :book
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Articles',
                                                                      count: @counts[Resource::RESOURCE_TYPES[:article]],
-                                                                     list: Resource.articles.order("RANDOM()").limit(6)
+                                                                     list: @articles,
+                                                                     resource_type: :article
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Reports',
                                                                      count: @counts[Resource::RESOURCE_TYPES[:report]],
-                                                                     list: Resource.reports.order("RANDOM()").limit(6)
+                                                                     list: @reports,
+                                                                     resource_type: :report
                 .item
                   .row
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Audio',
                                                                      count: @counts[Resource::RESOURCE_TYPES[:audio]],
-                                                                     list: Resource.audios.order("RANDOM()").limit(6)
+                                                                     list: @audios,
+                                                                     resource_type: :audio
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Courses',
                                                                      count: @counts[Resource::RESOURCE_TYPES[:course]],
-                                                                     list: Resource.courses.order("RANDOM()").limit(6)
+                                                                     list: @courses,
+                                                                     resource_type: :course
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Datasets',
                                                                      count: @counts[Resource::RESOURCE_TYPES[:dataset]],
-                                                                     list: Resource.datasets.order("RANDOM()").limit(6)
+                                                                     list: @datasets,
+                                                                     resource_type: :dataset
                 .item
                   .row
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Syllabi',
                                                                      count: @counts[Resource::RESOURCE_TYPES[:syllabus]],
-                                                                     list: Resource.syllabuses.order("RANDOM()").limit(6)
+                                                                     list: @syllabuses,
+                                                                     resource_type: :syllabus
                     .col-xs-12.col-sm-4.col-md-4
                       = render 'shared/components/resource_details', title: 'Video',
                                                                      count: @counts[Resource::RESOURCE_TYPES[:video]],
-                                                                     list: Resource.videos.order("RANDOM()").limit(6)
+                                                                     list: @videos,
+                                                                     resource_type: :video
           .row
             .col-xs-12.col-md-8.col-md-offset-2
               ol.carousel-indicators.gc-carousel-indicators
                 li.gc-carousel-indicator.active data-slide-to="0" data-target="#carousel-content"
                 li.gc-carousel-indicator data-slide-to="1" data-target="#carousel-content"
                 li.gc-carousel-indicator data-slide-to="2" data-target="#carousel-content"
-

--- a/spec/controllers/static_pages_controller_spec.rb
+++ b/spec/controllers/static_pages_controller_spec.rb
@@ -7,7 +7,17 @@ RSpec.describe StaticPagesController, type: :controller do
     end
 
     let(:counts) do
-      { 0 => 20, 1 => 20, 3 => 20, 4 => 20 }
+      {
+        0 => 20,
+        1 => 20,
+        2 => 20,
+        3 => 20,
+        4 => 20,
+        5 => 20,
+        6 => 20,
+        8 => 20,
+        9 => 20
+      }
     end
 
     before do
@@ -17,6 +27,11 @@ RSpec.describe StaticPagesController, type: :controller do
         create(:article)
         create(:url)
         create(:audio)
+        create(:report)
+        create(:course)
+        create(:dataset)
+        create(:syllabus)
+        create(:video)
       end
       perform_request
     end
@@ -27,6 +42,14 @@ RSpec.describe StaticPagesController, type: :controller do
 
     it 'assigns 10 random networks' do
       expect(assigns(:networks).count).to eq(10)
+    end
+
+    %i(article book report audio course dataset syllabus video).
+      each do |resource_type|
+
+      it "assigns 6 random #{resource_type}" do
+        expect(assigns(resource_type.to_s.pluralize).count).to eq(6)
+      end
     end
 
     it 'assigns resource count by resource type' do

--- a/spec/factories/resources.rb
+++ b/spec/factories/resources.rb
@@ -23,4 +23,28 @@ FactoryGirl.define do
   factory :audio, parent: :resource do
     resource_type { :audio }
   end
+
+  factory :course, parent: :resource do
+    resource_type { :course }
+  end
+
+  factory :dataset, parent: :resource do
+    resource_type { :dataset }
+  end
+
+  factory :image, parent: :resource do
+    resource_type { :image }
+  end
+
+  factory :syllabus, parent: :resource do
+    resource_type { :syllabus }
+  end
+
+  factory :video, parent: :resource do
+    resource_type { :video }
+  end
+
+  factory :profile, parent: :resource do
+    resource_type { :profile }
+  end
 end

--- a/spec/feature/user_visits_home_page_spec.rb
+++ b/spec/feature/user_visits_home_page_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.feature 'User visits home page' do
+  scenario 'can go to the search page for a specific resource' do
+    visit('/')
+    all('a.resource-details__see-more')[0].click
+    expect(find('#filters_model_types_resources')['checked']).to eq(true)
+    expect(find('#filters_resource_types_books')['checked']).to eq(true)
+
+    expect(find('#filters_model_types_lists')['checked']).to eq(false)
+    expect(find('#filters_model_types_networks')['checked']).to eq(false)
+    %w(article report audio url image profile course dataset syllabus video).
+      each do |resource_type|
+      expect(find("#filters_resource_types_#{resource_type.pluralize}")['checked']).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
  * "See more" links have been replaced by "View all"  
  * Arrow icon on "View All" links have been removed
  * "View All" link now points to the search page

https://github.com/greencommons/commons/issues/199