### PR TITLE
add airbnb eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+// Use this file as a starting point for your project's .eslintrc.
+// Copy this file, and add rule overrides as needed.
+{
+  "extends": "airbnb"
+}

--- a/.hound.yml
+++ b/.hound.yml
@@ -4,3 +4,6 @@ scss:
 ruby:
   config_file: .rubocop.yml
   fail_on_violations: true
+
+eslint:
+  enabled: true


### PR DESCRIPTION
## Reason for change

We'd like to start linting for our ES6 classes.

## Changes

- add `eslint` linting to hound
- add `.eslintrc` and extend the Airbnb style