### PR TITLE
Issue #205 - Implement cancel button for forms

### DIFF
--- a/app/helpers/link_helper.rb
+++ b/app/helpers/link_helper.rb
@@ -10,4 +10,21 @@ module LinkHelper
       'List' => '#'
     }[resource.class.to_s]
   end
+
+  def link_to_back(title, *options)
+    to_back = begin
+      if back_to_previous_page?
+        :back
+      else
+        root_url
+      end
+    end
+    link_to(title, to_back, *options)
+  end
+
+  def back_to_previous_page?
+    request.env['HTTP_REFERER'].present? &&
+       request.env['HTTP_REFERER'].include?(request.host) &&
+       !request.env['HTTP_REFERER'].match(/new|edit/)
+  end
 end

--- a/app/views/lists/_form.html.slim
+++ b/app/views/lists/_form.html.slim
@@ -31,6 +31,7 @@
           .checkbox
             = f.check_box :privacy, { class: 'checkbox--yellow' }, 'priv', 'publ'
             | Make private
-        .form-group
-          .pull-right
-            = f.submit submit_label, class: 'form-control btn btn-gc'
+      .pull-right
+        = link_to_back('Cancel', class: 'btn btn-white')
+        span<>
+        = f.button submit_label, class: "btn btn-gc"

--- a/app/views/networks/_form.html.slim
+++ b/app/views/networks/_form.html.slim
@@ -27,6 +27,7 @@
               = f.text_field :tag_list, value: @network.cached_tags.join(', '),
                                         class: 'form-control',
                                         placeholder: 'Separate tags with commas...'
-        .form-group
-          .pull-right
-            = f.submit submit_label, class: 'form-control btn btn-gc'
+      .pull-right
+        = link_to_back('Cancel', class: 'btn btn-white')
+        span<>
+        = f.button submit_label, class: "btn btn-gc"

--- a/app/views/resources/_form.html.slim
+++ b/app/views/resources/_form.html.slim
@@ -17,6 +17,7 @@
         .form-group
           = f.label :url, "URL", class: "control-label"
           = f.text_field :url, class: "form-control", placeholder: "Resource URL..."
-        .form-group
-          .pull-right
-            = f.submit submit_label, class: "form-control btn btn-gc"
+      .pull-right
+        = link_to_back('Cancel', class: 'btn btn-white')
+        span<>
+        = f.button submit_label, class: "btn btn-gc"

--- a/spec/feature/user_manages_lists_spec.rb
+++ b/spec/feature/user_manages_lists_spec.rb
@@ -44,6 +44,17 @@ RSpec.feature 'Managing lists', :worker, :elasticsearch do
       expect(page).to have_text "#{network.name} (Network)"
     end
 
+    scenario 'user can cancel and gets redirected to the previous page' do
+      feature_login
+
+      find(:css, '.glyphicon.glyphicon-plus').click
+      click_link 'Create List'
+      within('#new_list') do
+        click_on 'Cancel'
+      end
+      expect(page).to have_current_path('/')
+    end
+
     scenario 'users can create a private list owned by a network' do
       user = feature_login
       network = create(:network, name: 'test')

--- a/spec/feature/user_manages_networks_spec.rb
+++ b/spec/feature/user_manages_networks_spec.rb
@@ -22,6 +22,17 @@ RSpec.feature 'Managing networks' do
     expect(page).to have_content('tags')
   end
 
+  scenario 'user can cancel and gets redirected to the previous page' do
+    feature_login
+
+    find(:css, '.glyphicon.glyphicon-plus').click
+    click_link 'Create Network'
+    within('#new_network') do
+      click_on 'Cancel'
+    end
+    expect(page).to have_current_path('/')
+  end
+
   scenario 'network admins can update a network' do
     user = feature_login
     network = create(:network)

--- a/spec/feature/user_manages_resources_spec.rb
+++ b/spec/feature/user_manages_resources_spec.rb
@@ -40,6 +40,17 @@ RSpec.feature 'Managing resources' do
     expect(Resource.count).to eq 1
   end
 
+  scenario 'user can cancel and gets redirected to the previous page' do
+    feature_login
+
+    find(:css, '.glyphicon.glyphicon-plus').click
+    click_link 'Add Resource'
+    within('#new_resource') do
+      click_on 'Cancel'
+    end
+    expect(page).to have_current_path('/')
+  end
+
   scenario 'users can update a resource' do
     user = feature_login
     resource = create(:resource, resource_type: :url, url: 'http://example.com', user: user)

--- a/spec/helpers/link_helper_spec.rb
+++ b/spec/helpers/link_helper_spec.rb
@@ -1,0 +1,51 @@
+require 'rails_helper'
+
+RSpec.describe LinkHelper, type: :helper do
+  include LinkHelper
+
+  describe '#link_to_back' do
+    let(:title) { 'Link Title' }
+    let(:result) { link_to_back(title) }
+    let(:request) { double('request') }
+    let(:env) { { 'HTTP_REFERER' => http_referrer } }
+    let(:http_referrer) { nil }
+    let(:host) { 'greencommons' }
+
+    before do
+      allow(request).to receive(:env).and_return(env)
+      allow(request).to receive(:host).and_return(host)
+    end
+
+    context 'when the referrer is present' do
+      context 'when the referrer includes the host' do
+        context 'when the referrer is not a form page' do
+          let(:http_referrer) { host }
+
+          it 'returns a link to root path' do
+            expect(result).to eq('<a href="javascript:history.back()">Link Title</a>')
+          end
+        end
+        context 'when the referrer is a form page' do
+          let(:http_referrer) { "#{host}/new" }
+
+          it 'returns a link to root path' do
+            expect(result).to eq('<a href="http://test.host/">Link Title</a>')
+          end
+        end
+      end
+      context 'when the referrer do not includes the host' do
+        let(:http_referrer) { 'different_site' }
+
+        it 'returns a link to root path' do
+          expect(result).to eq('<a href="http://test.host/">Link Title</a>')
+        end
+      end
+    end
+
+    context 'when the referrer is not present' do
+      it 'returns a link to root path' do
+        expect(result).to eq('<a href="http://test.host/">Link Title</a>')
+      end
+    end
+  end
+end


### PR DESCRIPTION
  * Resource, Network and List forms have a cancel button
  * The cancel button goes to the previous page
  * If there is no previous page or the previous page is a form, goes to root page

https://github.com/greencommons/commons/pull/205