### PR TITLE
Issue #271 - add rollbar for error reporting.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'bootstrap-tagsinput-rails'
 gem 'selectize-rails'
 gem 'scout_apm'
 gem 'pdf-reader'
+gem 'rollbar'
 
 group :development do
   gem 'bummr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,6 +322,8 @@ GEM
     request_store (1.3.1)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    rollbar (2.15.4)
+      multi_json
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
       rspec-expectations (~> 3.5.0)
@@ -462,6 +464,7 @@ DEPENDENCIES
   rails (~> 5.0.0, >= 5.0.0.1)
   rails-controller-testing
   react-rails (~> 1.10)
+  rollbar
   rspec-rails (~> 3.5)
   rspec-wait
   rubocop

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,0 +1,57 @@
+Rollbar.configure do |config|
+  # Without configuration, Rollbar is enabled in all environments.
+  # To disable in specific environments, set config.enabled=false.
+
+  config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+
+  # Here we'll disable in 'test':
+  if Rails.env.test?
+    config.enabled = false
+  end
+
+  # By default, Rollbar will try to call the `current_user` controller method
+  # to fetch the logged-in user object, and then call that object's `id`,
+  # `username`, and `email` methods to fetch those properties. To customize:
+  # config.person_method = "my_current_user"
+  # config.person_id_method = "my_id"
+  # config.person_username_method = "my_username"
+  # config.person_email_method = "my_email"
+
+  # If you want to attach custom data to all exception and message reports,
+  # provide a lambda like the following. It should return a hash.
+  # config.custom_data_method = lambda { {:some_key => "some_value" } }
+
+  # Add exception class names to the exception_level_filters hash to
+  # change the level that exception is reported at. Note that if an exception
+  # has already been reported and logged the level will need to be changed
+  # via the rollbar interface.
+  # Valid levels: 'critical', 'error', 'warning', 'info', 'debug', 'ignore'
+  # 'ignore' will cause the exception to not be reported at all.
+  # config.exception_level_filters.merge!('MyCriticalException' => 'critical')
+  #
+  # You can also specify a callable, which will be called with the exception instance.
+  # config.exception_level_filters.merge!('MyCriticalException' => lambda { |e| 'critical' })
+
+  # Enable asynchronous reporting (uses girl_friday or Threading if girl_friday
+  # is not installed)
+  # config.use_async = true
+  # Supply your own async handler:
+  # config.async_handler = Proc.new { |payload|
+  #  Thread.new { Rollbar.process_from_async_handler(payload) }
+  # }
+
+  # Enable asynchronous reporting (using sucker_punch)
+  # config.use_sucker_punch
+
+  # Enable delayed reporting (using Sidekiq)
+  # config.use_sidekiq
+  # You can supply custom Sidekiq options:
+  # config.use_sidekiq 'queue' => 'default'
+
+  # If you run your staging application instance in production environment then
+  # you'll want to override the environment reported by `Rails.env` with an
+  # environment variable like this: `ROLLBAR_ENV=staging`. This is a recommended
+  # setup for Heroku. See:
+  # https://devcenter.heroku.com/articles/deploying-to-a-custom-rails-environment
+  config.environment = ENV['ROLLBAR_ENV'].presence || Rails.env
+end


### PR DESCRIPTION
## Reason for change

Error reporting and management is useful for monitoring failures in production environments.

## Changes

- gem `rollbar`added
- rollbar configuration file added

