### PR TITLE
Set up SendGrid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@
 # Ignore Redis database
 dump.rdb
 public/uploads/*
+
+.ruby-gemset

--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,0 +1,1 @@
+commons

--- a/.ruby-gemset
+++ b/.ruby-gemset
@@ -1,1 +1,0 @@
-commons

--- a/Gemfile
+++ b/Gemfile
@@ -39,6 +39,10 @@ gem 'scout_apm'
 gem 'pdf-reader'
 gem 'rollbar'
 
+group :production do
+  gem 'sendgrid-ruby'
+end
+
 group :development do
   gem 'bummr'
   gem 'bundler-audit'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,6 +86,17 @@ Rails.application.configure do
   config.active_record.dump_schema_after_migration = false
 
   ### CUSTOM SETTINGS ###
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.perform_deliveries = true
+  config.action_mailer.smtp_settings = {
+    user_name: ENV['SENDGRID_USERNAME'],
+    password: ENV['SENDGRID_PASSWORD'],
+    domain: ENV['HOST'],
+    address: 'smtp.sendgrid.net',
+    port: 587,
+    authentication: :plain,
+    enable_starttls_auto: true
+  }
 
   # Devise
   config.action_mailer.default_url_options = { host: ENV['HOST'] }


### PR DESCRIPTION
## Reason for change

We're getting an error message on production when trying to send emails: 

```
Errno::ECONNREFUSED (Connection refused - connect(2) for "localhost" port 25):
```

According to [this StackOverflow post](https://stackoverflow.com/questions/17141004/errnoeconnrefused-connection-refused-connect2-for-action-mailer), it appears we haven't set up ActionMailer correctly on production.

## Changes

- Add a `.ruby-gemset` file for easy gemset selection in RVM
- Add `sendgridy-ruby` gem in the production group
- Set up SMTP options in `production.rb`